### PR TITLE
update conda and remove unused dependencies

### DIFF
--- a/Miniforge3/construct.yaml
+++ b/Miniforge3/construct.yaml
@@ -1,5 +1,5 @@
 name: Miniforge3
-version: 4.8.2-1
+version: 4.8.2-0
 
 channels:
   - https://conda.anaconda.org/conda-forge

--- a/Miniforge3/construct.yaml
+++ b/Miniforge3/construct.yaml
@@ -1,5 +1,5 @@
 name: Miniforge3
-version: 4.7.12-1
+version: 4.8.2-1
 
 channels:
   - https://conda.anaconda.org/conda-forge
@@ -12,6 +12,4 @@ license_file: ../LICENSE
 
 specs:
   - python 3.7.*
-  - conda 4.7.12
-  - pip
-  - bzip2
+  - conda 4.8.2

--- a/Miniforge3/construct.yaml
+++ b/Miniforge3/construct.yaml
@@ -13,3 +13,5 @@ license_file: ../LICENSE
 specs:
   - python 3.7.*
   - conda 4.8.2
+  - pip
+  - bzip2


### PR DESCRIPTION
This PR updates conda to version 4.8.2, also the following dependencies listed in `construct.yaml` are removed:
  - pip (as Python itself depends on pip)
  - bipz2 (as Python is statically linked to bipz2)
