### PR TITLE
remove notice about work being very experimental

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 
 This repository holds a minimal installer for conda on platforms that conda-forge supports but that aren't supported by [Miniconda](https://docs.conda.io/en/latest/miniconda.html).
 
-**Important: This work is still very experimental.**
-
 Relevant conversations:
 
 - https://github.com/conda-forge/conda-forge.github.io/issues/871#issue-496677528


### PR DESCRIPTION
I have tested the current installer on an aarch64 system and didn't find any problems with it.  I was able to install many libraries using conda and also able to create a Python 3.8 environment (and install libraries therein).  Having a note saying "This work is still very experimental." will discourage many users to give miniforge a try.