### PR TITLE
Provide Miniforge3+mamba as Mambaforge3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,64 +11,64 @@ jobs:
         include:
           - os: windows-latest
             ARCH: x86_64
-            MINIFORGE_NAME: "Miniforge3"
+            MINIFORGE_NAME: "Mambaforge3"
             OS_NAME: "Windows"
 
           - os: macos-latest
             ARCH: arm64
-            MINIFORGE_NAME: "Miniforge3"
+            MINIFORGE_NAME: "Mambaforge3"
             OS_NAME: "MacOSX"
 
           - os: macos-latest
             ARCH: x86_64
-            MINIFORGE_NAME: "Miniforge-pypy3"
+            MINIFORGE_NAME: "Mambaforge-pypy3"
             OS_NAME: "MacOSX"
 
           - os: macos-latest
             ARCH: x86_64
-            MINIFORGE_NAME: "Miniforge3"
+            MINIFORGE_NAME: "Mambaforge3"
             OS_NAME: "MacOSX"
 
           - os: ubuntu-latest
             ARCH: aarch64
             DOCKER_ARCH: arm64v8
             DOCKERIMAGE: condaforge/linux-anvil-aarch64
-            MINIFORGE_NAME: "Miniforge3"
+            MINIFORGE_NAME: "Mambaforge3"
             OS_NAME: "Linux"
 
           - os: ubuntu-latest
             ARCH: x86_64
             DOCKER_ARCH: amd64
             DOCKERIMAGE: condaforge/linux-anvil-comp7
-            MINIFORGE_NAME: "Miniforge3"
+            MINIFORGE_NAME: "Mambaforge3"
             OS_NAME: "Linux"
 
           - os: ubuntu-latest
             ARCH: ppc64le
             DOCKER_ARCH: ppc64le
             DOCKERIMAGE: condaforge/linux-anvil-ppc64le
-            MINIFORGE_NAME: "Miniforge3"
+            MINIFORGE_NAME: "Mambaforge3"
             OS_NAME: "Linux"
 
           - os: ubuntu-latest
             ARCH: aarch64
             DOCKER_ARCH: arm64v8
             DOCKERIMAGE: condaforge/linux-anvil-aarch64
-            MINIFORGE_NAME: "Miniforge-pypy3"
+            MINIFORGE_NAME: "Mambaforge-pypy3"
             OS_NAME: "Linux"
 
           - os: ubuntu-latest
             ARCH: x86_64
             DOCKER_ARCH: amd64
             DOCKERIMAGE: condaforge/linux-anvil-comp7
-            MINIFORGE_NAME: "Miniforge-pypy3"
+            MINIFORGE_NAME: "Mambaforge-pypy3"
             OS_NAME: "Linux"
 
           - os: ubuntu-latest
             ARCH: ppc64le
             DOCKER_ARCH: ppc64le
             DOCKERIMAGE: condaforge/linux-anvil-ppc64le
-            MINIFORGE_NAME: "Miniforge-pypy3"
+            MINIFORGE_NAME: "Mambaforge-pypy3"
             OS_NAME: "Linux"
 
     steps:
@@ -113,7 +113,7 @@ jobs:
       uses: svenstaro/upload-release-action@v2
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: build/Miniforge*
+        file: build/*forge*
         tag: ${{ github.ref }}
         overwrite: true
         file_glob: true

--- a/Miniforge3/construct.yaml
+++ b/Miniforge3/construct.yaml
@@ -1,5 +1,9 @@
-{% set version = os.environ.get("MINIFORGE_VERSION", "4.9.2-0") %}
 {% set name = os.environ.get("MINIFORGE_NAME", "Miniforge3") %}
+{% if name.startswith("Mamba") %}
+{% set version = os.environ.get("MINIFORGE_VERSION", "4.9.2-0.7.3-0") %}
+{% else %}
+{% set version = os.environ.get("MINIFORGE_VERSION", "4.9.2-0") %}
+{% endif %}
 
 name: {{ name }}
 version: {{ version }}
@@ -26,5 +30,8 @@ specs:
   - python 3.6.* *_pypy
 {% endif %}
   - conda {{ version.split("-")[0] }}
+{% if name.startswith("Mamba") %}
+  - mamba {{ version.split("-")[1] }}
+{% endif %}
   - pip
   - bzip2

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -42,7 +42,7 @@ constructor $TEMP_DIR/Miniforge3/ --output-dir $TEMP_DIR $EXTRA_CONSTRUCTOR_ARGS
 echo "***** Generate installer hash *****"
 cd $TEMP_DIR
 # This line ill break if there is more than one installer in the folder.
-INSTALLER_PATH=$(find . -name "Miniforge*.sh" -or -name "Miniforge*.exe" | head -n 1)
+INSTALLER_PATH=$(find . -name "*forge*.sh" -or -name "*forge*.exe" | head -n 1)
 HASH_PATH="$INSTALLER_PATH.sha256"
 sha256sum $INSTALLER_PATH > $HASH_PATH
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -11,7 +11,7 @@ CONSTRUCT_ROOT="${CONSTRUCT_ROOT:-$PWD}"
 cd ${CONSTRUCT_ROOT}
 
 echo "***** Get the installer *****"
-INSTALLER_PATH=$(find build/ -name "Miniforge*.sh" -or -name "Miniforge*.exe"| head -n 1)
+INSTALLER_PATH=$(find build/ -name "*forge*.sh" -or -name "*forge*.exe"| head -n 1)
 
 echo "***** Run the installer *****"
 chmod +x $INSTALLER_PATH


### PR DESCRIPTION
Proposal for #23 

Currently this is a hard rename of the CI jobs to keep the matrix, I would though reintroduce `Miniforge` again before we merge this.