### PR TITLE
Add note for OSX arm64 installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Miniforge installers are available here: https://github.com/conda-forge/miniforg
 
 #### Miniforge3
 
-Latest installers with python 3.8 in the base environment
+Latest installers with python 3.8 `(*)` in the base environment `(**)`
 
 | OS      | Architecture          | Download  |
 | --------|-----------------------|-----------|
@@ -23,7 +23,9 @@ Latest installers with python 3.8 in the base environment
 | OS X    | arm64 (Apple Silicon) | [Miniforge3-MacOSX-arm64](https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-arm64.sh) |
 | Windows | x86_64                | [Miniforge3-Windows-x86_64](https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Windows-x86_64.exe) |
 
-* OS X arm64 will be installed with Python 3.9
+`(*)` OS X arm64 will be installed with Python 3.9
+
+`(**)` the python version is specific only to the base environment. installed conda can create new environments with different python versions and implementations
 
 #### Miniforge-pypy3
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Latest installers with python 3.8 in the base environment
 | OS X    | arm64 (Apple Silicon) | [Miniforge3-MacOSX-arm64](https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-arm64.sh) |
 | Windows | x86_64                | [Miniforge3-Windows-x86_64](https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Windows-x86_64.exe) |
 
+* OS X arm64 will be installed with Python 3.9
+
 #### Miniforge-pypy3
 
 Latest installers with pypy3.6 in the base environment


### PR DESCRIPTION
Added a note for OSX arm64 installer that it will install Python 3.9 instead of Python 3.8.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
