### PR TITLE
Add miniforge_console_shortcut on windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ jobs:
   build:
     name: ${{ matrix.MINIFORGE_NAME }}-${{ matrix.OS_NAME }}-${{ matrix.ARCH }}
     runs-on: ${{ matrix.os }}
+    env:
+      UPLOAD_ARTEFACTS: true
     strategy:
       fail-fast: false
       matrix:
@@ -170,6 +172,12 @@ jobs:
         cp build/$MINIFORGE_NAME-*-$OS_NAME-$ARCH.$EXT build/$MINIFORGE_NAME-$OS_NAME-$ARCH.$EXT
         ls -alh build
       shell: bash
+
+    - name: Upload miniforge to release
+      if: env.UPLOAD_ARTEFACTS && ${{ !startsWith(github.ref, 'refs/tags/') }}
+      uses: actions/upload-artifact@v2
+      with:
+        path: build/M*forge*
 
     - name: Upload miniforge to release
       uses: svenstaro/upload-release-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,6 +196,7 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         path: build/${{ matrix.MINIFORGE_NAME }}-${{ matrix.OS_NAME }}-${{ matrix.ARCH }}*
+        name: ${{ matrix.MINIFORGE_NAME }}-${{ matrix.OS_NAME }}-${{ matrix.ARCH }}
 
     - name: Upload miniforge to release
       uses: svenstaro/upload-release-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,6 @@ jobs:
   build:
     name: ${{ matrix.MINIFORGE_NAME }}-${{ matrix.OS_NAME }}-${{ matrix.ARCH }}
     runs-on: ${{ matrix.os }}
-    env:
-      UPLOAD_ARTEFACTS: true
     strategy:
       fail-fast: false
       matrix:
@@ -15,11 +13,13 @@ jobs:
             ARCH: x86_64
             MINIFORGE_NAME: "Miniforge3"
             OS_NAME: "Windows"
+            UPLOAD_ARTEFACTS: true
 
           - os: windows-latest
             ARCH: x86_64
             MINIFORGE_NAME: "Mambaforge"
             OS_NAME: "Windows"
+            UPLOAD_ARTEFACTS: true
 
           - os: macos-latest
             ARCH: arm64
@@ -173,11 +173,11 @@ jobs:
         ls -alh build
       shell: bash
 
-    - name: Upload miniforge to release
-      if: env.UPLOAD_ARTEFACTS && ${{ !startsWith(github.ref, 'refs/tags/') }}
+    - name: Upload miniforge to Github artefact
+      if: ${{ matrix.UPLOAD_ARTEFACTS && !startsWith(github.ref, 'refs/tags/') }}
       uses: actions/upload-artifact@v2
       with:
-        path: build/M*forge*
+        path: build/${{ matrix.MINIFORGE_NAME }}-${{ matrix.OS_NAME }}-${{ matrix.ARCH }}*
 
     - name: Upload miniforge to release
       uses: svenstaro/upload-release-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,49 +13,41 @@ jobs:
             ARCH: x86_64
             MINIFORGE_NAME: "Miniforge3"
             OS_NAME: "Windows"
-            UPLOAD_ARTEFACT: true
 
           - os: windows-latest
             ARCH: x86_64
             MINIFORGE_NAME: "Mambaforge"
             OS_NAME: "Windows"
-            UPLOAD_ARTEFACT: true
 
           - os: macos-latest
             ARCH: arm64
             MINIFORGE_NAME: "Miniforge3"
             OS_NAME: "MacOSX"
-            UPLOAD_ARTEFACT: false
 
           - os: macos-latest
             ARCH: arm64
             MINIFORGE_NAME: "Mambaforge"
             OS_NAME: "MacOSX"
-            UPLOAD_ARTEFACT: false
 
           - os: macos-latest
             ARCH: x86_64
             MINIFORGE_NAME: "Miniforge-pypy3"
             OS_NAME: "MacOSX"
-            UPLOAD_ARTEFACT: false
 
           - os: macos-latest
             ARCH: x86_64
             MINIFORGE_NAME: "Mambaforge-pypy3"
             OS_NAME: "MacOSX"
-            UPLOAD_ARTEFACT: false
 
           - os: macos-latest
             ARCH: x86_64
             MINIFORGE_NAME: "Miniforge3"
             OS_NAME: "MacOSX"
-            UPLOAD_ARTEFACT: false
 
           - os: macos-latest
             ARCH: x86_64
             MINIFORGE_NAME: "Mambaforge"
             OS_NAME: "MacOSX"
-            UPLOAD_ARTEFACT: false
 
           - os: ubuntu-latest
             ARCH: aarch64
@@ -63,7 +55,6 @@ jobs:
             DOCKERIMAGE: condaforge/linux-anvil-aarch64
             MINIFORGE_NAME: "Miniforge3"
             OS_NAME: "Linux"
-            UPLOAD_ARTEFACT: false
 
           - os: ubuntu-latest
             ARCH: aarch64
@@ -71,7 +62,6 @@ jobs:
             DOCKERIMAGE: condaforge/linux-anvil-aarch64
             MINIFORGE_NAME: "Mambaforge"
             OS_NAME: "Linux"
-            UPLOAD_ARTEFACT: false
 
           - os: ubuntu-latest
             ARCH: x86_64
@@ -79,7 +69,6 @@ jobs:
             DOCKERIMAGE: condaforge/linux-anvil-comp7
             MINIFORGE_NAME: "Miniforge3"
             OS_NAME: "Linux"
-            UPLOAD_ARTEFACT: false
 
           - os: ubuntu-latest
             ARCH: x86_64
@@ -87,7 +76,6 @@ jobs:
             DOCKERIMAGE: condaforge/linux-anvil-comp7
             MINIFORGE_NAME: "Mambaforge"
             OS_NAME: "Linux"
-            UPLOAD_ARTEFACT: false
 
           - os: ubuntu-latest
             ARCH: ppc64le
@@ -95,7 +83,6 @@ jobs:
             DOCKERIMAGE: condaforge/linux-anvil-ppc64le
             MINIFORGE_NAME: "Miniforge3"
             OS_NAME: "Linux"
-            UPLOAD_ARTEFACT: false
 
           - os: ubuntu-latest
             ARCH: ppc64le
@@ -103,7 +90,6 @@ jobs:
             DOCKERIMAGE: condaforge/linux-anvil-ppc64le
             MINIFORGE_NAME: "Mambaforge"
             OS_NAME: "Linux"
-            UPLOAD_ARTEFACT: false
 
           - os: ubuntu-latest
             ARCH: aarch64
@@ -111,7 +97,6 @@ jobs:
             DOCKERIMAGE: condaforge/linux-anvil-aarch64
             MINIFORGE_NAME: "Miniforge-pypy3"
             OS_NAME: "Linux"
-            UPLOAD_ARTEFACT: false
 
           - os: ubuntu-latest
             ARCH: aarch64
@@ -119,7 +104,6 @@ jobs:
             DOCKERIMAGE: condaforge/linux-anvil-aarch64
             MINIFORGE_NAME: "Mambaforge-pypy3"
             OS_NAME: "Linux"
-            UPLOAD_ARTEFACT: false
 
           - os: ubuntu-latest
             ARCH: x86_64
@@ -127,7 +111,6 @@ jobs:
             DOCKERIMAGE: condaforge/linux-anvil-comp7
             MINIFORGE_NAME: "Miniforge-pypy3"
             OS_NAME: "Linux"
-            UPLOAD_ARTEFACT: false
 
           - os: ubuntu-latest
             ARCH: x86_64
@@ -135,7 +118,6 @@ jobs:
             DOCKERIMAGE: condaforge/linux-anvil-comp7
             MINIFORGE_NAME: "Mambaforge-pypy3"
             OS_NAME: "Linux"
-            UPLOAD_ARTEFACT: false
 
           - os: ubuntu-latest
             ARCH: ppc64le
@@ -143,7 +125,6 @@ jobs:
             DOCKERIMAGE: condaforge/linux-anvil-ppc64le
             MINIFORGE_NAME: "Miniforge-pypy3"
             OS_NAME: "Linux"
-            UPLOAD_ARTEFACT: false
 
           - os: ubuntu-latest
             ARCH: ppc64le
@@ -151,7 +132,6 @@ jobs:
             DOCKERIMAGE: condaforge/linux-anvil-ppc64le
             MINIFORGE_NAME: "Mambaforge-pypy3"
             OS_NAME: "Linux"
-            UPLOAD_ARTEFACT: false
 
     steps:
     - name: Checkout code
@@ -192,7 +172,7 @@ jobs:
       shell: bash
 
     - name: Upload miniforge to Github artefact
-      if: ${{ matrix.UPLOAD_ARTEFACT && !startsWith(github.ref, 'refs/tags/') }}
+      if: ${{ !startsWith(github.ref, 'refs/tags/') }}
       uses: actions/upload-artifact@v2
       with:
         path: build/${{ matrix.MINIFORGE_NAME }}-${{ matrix.OS_NAME }}-${{ matrix.ARCH }}*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,43 +13,49 @@ jobs:
             ARCH: x86_64
             MINIFORGE_NAME: "Miniforge3"
             OS_NAME: "Windows"
-            UPLOAD_ARTEFACTS: true
+            UPLOAD_ARTEFACT: true
 
           - os: windows-latest
             ARCH: x86_64
             MINIFORGE_NAME: "Mambaforge"
             OS_NAME: "Windows"
-            UPLOAD_ARTEFACTS: true
+            UPLOAD_ARTEFACT: true
 
           - os: macos-latest
             ARCH: arm64
             MINIFORGE_NAME: "Miniforge3"
             OS_NAME: "MacOSX"
+            UPLOAD_ARTEFACT: false
 
           - os: macos-latest
             ARCH: arm64
             MINIFORGE_NAME: "Mambaforge"
             OS_NAME: "MacOSX"
+            UPLOAD_ARTEFACT: false
 
           - os: macos-latest
             ARCH: x86_64
             MINIFORGE_NAME: "Miniforge-pypy3"
             OS_NAME: "MacOSX"
+            UPLOAD_ARTEFACT: false
 
           - os: macos-latest
             ARCH: x86_64
             MINIFORGE_NAME: "Mambaforge-pypy3"
             OS_NAME: "MacOSX"
+            UPLOAD_ARTEFACT: false
 
           - os: macos-latest
             ARCH: x86_64
             MINIFORGE_NAME: "Miniforge3"
             OS_NAME: "MacOSX"
+            UPLOAD_ARTEFACT: false
 
           - os: macos-latest
             ARCH: x86_64
             MINIFORGE_NAME: "Mambaforge"
             OS_NAME: "MacOSX"
+            UPLOAD_ARTEFACT: false
 
           - os: ubuntu-latest
             ARCH: aarch64
@@ -57,6 +63,7 @@ jobs:
             DOCKERIMAGE: condaforge/linux-anvil-aarch64
             MINIFORGE_NAME: "Miniforge3"
             OS_NAME: "Linux"
+            UPLOAD_ARTEFACT: false
 
           - os: ubuntu-latest
             ARCH: aarch64
@@ -64,6 +71,7 @@ jobs:
             DOCKERIMAGE: condaforge/linux-anvil-aarch64
             MINIFORGE_NAME: "Mambaforge"
             OS_NAME: "Linux"
+            UPLOAD_ARTEFACT: false
 
           - os: ubuntu-latest
             ARCH: x86_64
@@ -71,6 +79,7 @@ jobs:
             DOCKERIMAGE: condaforge/linux-anvil-comp7
             MINIFORGE_NAME: "Miniforge3"
             OS_NAME: "Linux"
+            UPLOAD_ARTEFACT: false
 
           - os: ubuntu-latest
             ARCH: x86_64
@@ -78,6 +87,7 @@ jobs:
             DOCKERIMAGE: condaforge/linux-anvil-comp7
             MINIFORGE_NAME: "Mambaforge"
             OS_NAME: "Linux"
+            UPLOAD_ARTEFACT: false
 
           - os: ubuntu-latest
             ARCH: ppc64le
@@ -85,6 +95,7 @@ jobs:
             DOCKERIMAGE: condaforge/linux-anvil-ppc64le
             MINIFORGE_NAME: "Miniforge3"
             OS_NAME: "Linux"
+            UPLOAD_ARTEFACT: false
 
           - os: ubuntu-latest
             ARCH: ppc64le
@@ -92,6 +103,7 @@ jobs:
             DOCKERIMAGE: condaforge/linux-anvil-ppc64le
             MINIFORGE_NAME: "Mambaforge"
             OS_NAME: "Linux"
+            UPLOAD_ARTEFACT: false
 
           - os: ubuntu-latest
             ARCH: aarch64
@@ -99,6 +111,7 @@ jobs:
             DOCKERIMAGE: condaforge/linux-anvil-aarch64
             MINIFORGE_NAME: "Miniforge-pypy3"
             OS_NAME: "Linux"
+            UPLOAD_ARTEFACT: false
 
           - os: ubuntu-latest
             ARCH: aarch64
@@ -106,6 +119,7 @@ jobs:
             DOCKERIMAGE: condaforge/linux-anvil-aarch64
             MINIFORGE_NAME: "Mambaforge-pypy3"
             OS_NAME: "Linux"
+            UPLOAD_ARTEFACT: false
 
           - os: ubuntu-latest
             ARCH: x86_64
@@ -113,6 +127,7 @@ jobs:
             DOCKERIMAGE: condaforge/linux-anvil-comp7
             MINIFORGE_NAME: "Miniforge-pypy3"
             OS_NAME: "Linux"
+            UPLOAD_ARTEFACT: false
 
           - os: ubuntu-latest
             ARCH: x86_64
@@ -120,6 +135,7 @@ jobs:
             DOCKERIMAGE: condaforge/linux-anvil-comp7
             MINIFORGE_NAME: "Mambaforge-pypy3"
             OS_NAME: "Linux"
+            UPLOAD_ARTEFACT: false
 
           - os: ubuntu-latest
             ARCH: ppc64le
@@ -127,6 +143,7 @@ jobs:
             DOCKERIMAGE: condaforge/linux-anvil-ppc64le
             MINIFORGE_NAME: "Miniforge-pypy3"
             OS_NAME: "Linux"
+            UPLOAD_ARTEFACT: false
 
           - os: ubuntu-latest
             ARCH: ppc64le
@@ -134,6 +151,7 @@ jobs:
             DOCKERIMAGE: condaforge/linux-anvil-ppc64le
             MINIFORGE_NAME: "Mambaforge-pypy3"
             OS_NAME: "Linux"
+            UPLOAD_ARTEFACT: false
 
     steps:
     - name: Checkout code
@@ -174,7 +192,7 @@ jobs:
       shell: bash
 
     - name: Upload miniforge to Github artefact
-      if: ${{ matrix.UPLOAD_ARTEFACTS && !startsWith(github.ref, 'refs/tags/') }}
+      if: ${{ matrix.UPLOAD_ARTEFACT && !startsWith(github.ref, 'refs/tags/') }}
       uses: actions/upload-artifact@v2
       with:
         path: build/${{ matrix.MINIFORGE_NAME }}-${{ matrix.OS_NAME }}-${{ matrix.ARCH }}*

--- a/Miniforge3/construct.yaml
+++ b/Miniforge3/construct.yaml
@@ -32,3 +32,4 @@ specs:
 
   - pip
   - bzip2
+  - miniforge_console_shortcut  # [win]


### PR DESCRIPTION
Fix #62.

- Add `miniforge_console_shortcut` on windows to add start menu shortcut
- Upload installer as github artefact when workflow doesn't run on tag.
