### PR TITLE
add release page prototype from gist

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,3 +15,8 @@ jobs:
         with:
           path: build/docs
           name: docs
+      - uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: build/docs/all-releases
+        if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,13 @@
+name: Build docs
+on: [push, pull_request]
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: pip install -r docs/requirements.txt
+      - run: python docs/releases.py
+      - uses: actions/upload-artifact@v2
+        with:
+          path: build/docs
+          name: docs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,10 +2,14 @@ name: Build docs
 on: [push, pull_request]
 jobs:
   docs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
+    defaults:
+      run:
+        shell: bash -l {0}
     steps:
       - uses: actions/checkout@v2
-      - run: pip install -r docs/requirements.txt
+      - uses: conda-incubator/setup-miniconda@v2
+      - run: python -m pip install -r docs/requirements.txt
       - run: python docs/releases.py
       - uses: actions/upload-artifact@v2
         with:

--- a/docs/releases.py
+++ b/docs/releases.py
@@ -1,0 +1,74 @@
+"""render a miniforge releases page"""
+import jinja2
+from pathlib import Path
+import datetime
+import sys
+import requests_cache
+
+HERE = Path(__file__).parent
+BUILD = HERE.parent / "build"
+DOCS = BUILD / "docs"
+
+# TODO: handle pagination
+BASE_URL = "https://api.github.com/repos/conda-forge/miniforge/releases?per_page=100"
+ENV = jinja2.Environment(loader=jinja2.FileSystemLoader([HERE / "templates"]))
+
+
+def get_releases():
+    """use the GitHub API to fetch release information"""
+    s = requests_cache.CachedSession(str(BUILD / "cache"))
+    releases = s.get(BASE_URL).json()
+
+    new_releases = []
+
+    for release in releases:
+        if release["draft"] or release["prerelease"]:
+            continue
+        new_assets = []
+        for asset in release["assets"]:
+            name = asset["name"]
+            if "sha256" in name:
+                continue
+            if release["tag_name"] not in name:
+                continue
+            if release["tag_name"] in asset["name"]:
+                asset["_variant"], os_plat = asset["name"].split(
+                    f"""-{release["tag_name"]}-"""
+                )
+                asset["_os"], asset["_arch"] = os_plat.split(".")[0].split("-")
+            else:
+                raise ValueError(f"Couldn't variant for {name}")
+            asset["_sha256"] = s.get(
+                f"""{asset["browser_download_url"]}.sha256"""
+            ).text.split(" ")[0]
+            new_assets += [asset]
+        release["assets"] = new_assets
+        new_releases += [release]
+    releases = new_releases
+    return releases
+
+
+def render(releases):
+    """render the release page HTML"""
+    context = dict(
+        title="Miniforge Releases", releases=releases, year=datetime.datetime.now().year
+    )
+    html = ENV.get_template("all-releases.html").render(**context)
+
+    release_html = DOCS / "all-releases" / "index.html"
+
+    if not release_html.parent.exists():
+        release_html.parent.mkdir(parents=True)
+
+    release_html.write_text(html, encoding="utf-8")
+
+
+def main():
+    """main entrypoint"""
+    releases = get_releases()
+    render(releases)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/releases.py
+++ b/docs/releases.py
@@ -9,6 +9,9 @@ HERE = Path(__file__).parent
 BUILD = HERE.parent / "build"
 DOCS = BUILD / "docs"
 
+if not DOCS.exists():
+    DOCS.mkdir(parents=True)
+
 # TODO: handle pagination
 BASE_URL = "https://api.github.com/repos/conda-forge/miniforge/releases?per_page=100"
 ENV = jinja2.Environment(loader=jinja2.FileSystemLoader([HERE / "templates"]))
@@ -56,9 +59,6 @@ def render(releases):
     html = ENV.get_template("all-releases.html").render(**context)
 
     release_html = DOCS / "all-releases" / "index.html"
-
-    if not release_html.parent.exists():
-        release_html.parent.mkdir(parents=True)
 
     release_html.write_text(html, encoding="utf-8")
 

--- a/docs/releases.py
+++ b/docs/releases.py
@@ -60,6 +60,9 @@ def render(releases):
 
     release_html = DOCS / "all-releases" / "index.html"
 
+    if not release_html.parent.exists():
+        release_html.parent.mkdir(parents=True)
+
     release_html.write_text(html, encoding="utf-8")
 
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+requests_cache
+jinja2

--- a/docs/templates/all-releases.html
+++ b/docs/templates/all-releases.html
@@ -1,0 +1,205 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>{{ title }}</title>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="Description" content="Download page for latest and historical Miniforge releases">
+  </head>
+  <style>
+    :root {
+      --cf-border-color: solid 1px rgba(255,255,255,0.25);
+      --cf-link-color: rgb(66, 220, 163);
+      --cf-anvil-img: url('data:image/svg+xml;base64,CjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2aWV3Qm94PSIwIDAgMjQgMjQiPgo8cGF0aCBmaWxsPSIjZmZmIiBkPSJNOC4yMDYgNS44NjZsLjAwNS4zOTZINi43NTRsLjAwNi42NTV2LjAwNWwtNi43NTguMDAydi4yMTFMMCA3Ljk3M2wuMDIuMDQxYy4yMTIuNDY3LjY2My45MDEgMS4yNTcgMS4zMTMuNTk0LjQxMSAxLjMzNS43OTYgMi4xNDUgMS4xMyAxLjYyLjY2NCAzLjUwMiAxLjEyIDUuMDA2IDEuMS43NDYtLjAxIDEuMjY1LjIyOCAxLjYyLjY3Mi4zNDEuNDI2LjUxIDEuMDkyLjUyNCAxLjkyTDcuOTQgMTYuMjM5bC4wMDggMS44OTZIMjAuMjlsLS4wMDQtMS43Ni0yLjYzLTIuMjJjLjA1NS0yLjAxMy43MDgtMy40NDMgMS43NzctNC40MDUgMS4wODctLjk3OSAyLjYxLTEuNDkgNC4zNy0xLjYxNmwuMTk1LS4wMTVMMjQgNS44NzJ6bS40MjUuNDIybDE0Ljk0Ni4wMDYtLjAwNCAxLjQ1N2MtMS43MzcuMTU1LTMuMjkuNjY2LTQuNDI0IDEuNjg1LS45MTIuODIyLTEuNDMzIDIuMDYyLTEuNjkxIDMuNTM0bC0xLjYxNy4wMDQuMDAyLjQyMiAxLjUzNS0uMDA0Yy0uMDI3LjIyNi0uMTEzLjQtLjEyMy42NGwtLjg5My0uMDAzLS4wMDIuNDIyLjk5NS4wMDQgMi4xMzggMS44MDItMi45NDEuMDAyYy0uNzI0LS42NzUtMS41NTItMS4xMTYtMi40MTYtMS4xNTgtLjgxNy0uMDQtMS42MzguMzI0LTIuMzg3IDEuMDRsLTIuOTc4LS4wMjQgMi4yNDgtMS43ODF2LS4xMDJjLjAwMi0uOTQzLS4yLTEuNzItLjY0LTIuMjY5LS4zOTYtLjQ5Ni0xLjAwNy0uNzQ5LTEuNzQxLS43OWwtLjAwOC00LjQ5aC4wMDh6bS0xLjQ1LjM5NmgxLjAyNmwuMDA4IDQuNDA0Yy0xLjM4Ny0uMDItMy4xMjUtLjQwNC00LjYzMS0xLjAyMy0uNzg3LS4zMjQtMS41MDctLjY5OC0yLjA2Ni0xLjA4NkMuOTY4IDguNi41ODcgOC4yMDMuNDI0IDcuODZ2LS41MTRsNi4zMzYtLjAwMnYyLjE2aC40MjJ2LTIuMTZoLjAwNGwtLjAwNC0uNDM1di0uMjI2em02LjkzNSA4LjgzOWMuNzUuMDM3IDEuNTAzLjQzNiAyLjE4IDEuMDc4bC0uMDAyIDEuMTEyaC00LjM0NWwtLjAwNi0xLjJjLjcwNi0uNzE3IDEuNDQzLTEuMDI2IDIuMTczLS45OXpNOC4zNiAxNi41MzdsMy4xNi4wMjMuMDA2IDEuMTUzaC0zLjE2em0xMS41LjE0MmwuMDAyIDEuMDM0aC0zLjE0OFYxNi42OHoiLz4KPC9zdmc+Cg==');
+      --cf-padding: 2em;
+    }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+      padding: 0;
+      margin: 0;
+      font-size: 15px;
+      line-height: 1.5;
+      box-sizing: border-box;
+      color: #fff;
+      background-color: #000;
+    }
+    header {
+      background-color: #000;
+      padding: 0 var(--cf-padding);
+      color: #fff;
+      z-index: 1;
+      border-bottom: solid 1px var(--cf-link-color);
+      display: flex;
+      align-items: center;
+      position: sticky;
+      top: 0;
+    }
+    article, h2 {
+      scroll-margin-top: 6rem;
+    }
+    footer {
+      border-top: solid 1px var(--cf-link-color);
+      background-color: #000;
+      padding: var(--cf-padding);
+      text-align: center;
+    }
+    h1 {
+      background-image: var(--cf-anvil-img);
+      background-repeat: no-repeat;
+      padding-left: 2em;
+    }
+    nav {
+      flex: 1;
+      display: flex;
+      flex-wrap: wrap;
+    }
+    nav ul {
+      flex: 1;
+      display: flex;
+    }
+    nav ul:last-child {
+      flex: 0;
+    }
+    nav ul li {
+      flex: 0;
+      list-style: none;
+    }
+    nav ul li a {
+      padding: 0.5em var(--cf-padding);
+      font-size: 150%;
+    }
+    main {
+      padding: var(--cf-padding);
+      background-color: rgba(255,255,255,0.05);
+    }
+    a, a code {
+      text-decoration: none;
+      color: var(--cf-link-color);
+    }
+    a:hover {
+      text-decoration: underline;
+    }
+    table {
+      border-collapse: collapse;
+      margin: auto;
+    }
+    td, th {
+      padding: 0.1em 0.5em;
+      vertical-align: center;
+    }
+    tbody tr:nth-child(odd) {
+      background-color: rgba(255,255,255,.05);
+    }
+    table pre {
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      display: inline-block;
+      max-width: 6em;
+      margin: 0;
+    }
+    label {
+      font-style: italic;
+    }
+    tr.variant-row {
+      border-top: var(--cf-border-color);
+    }
+    tr td, tr th {
+      border-bottom: var(--cf-border-color);
+    }
+
+    tr:hover td {
+      border-bottom: solid 1px var(--cf-link-color);
+    }
+    td:nth-last-child(2) {
+      text-align: right;
+    }
+  </style>
+  <body>
+    <header>
+      <h1>{{ title }}</h1>
+      <nav>
+        <ul>
+          <li><a href="#latest-release">Latest</a></li>
+          <li><a href="#history">History</a></li>
+        </ul>
+        <ul>
+          <li><a href="https://github.com/conda-forge/miniforge">Source</a></li>
+        </ul>
+      </nav>
+    </header>
+    <main>
+      {%- for release in releases %}
+      {% if loop.index0 == 0 %}
+      <h2 id="latest-release">Latest</h2>
+      {% elif loop.index0 == 1 %}
+      <h2 id="history">History</h2>
+      {% endif %}
+      <article id="{{ release.tag_name }}">
+        <h3>
+          Miniforge {{ release.tag_name }}
+          <a title="Link to {{ release.tag_name }}" href="#{{ release.tag_name }}">#</a>
+        </h3>
+        {%- if loop.index0 %}<details><summary>{% endif -%}
+        <label>
+          {{ release.assets | count }} artifact{% if release.assets | count > 1 %}s{% endif %}
+          <a href="{{ release.html_url }}">released</a>
+          <span title="{{ release.published_at }}">{{ release.published_at.split("T")[0] }}</span>
+        </label>
+        {%- if loop.index0 %}</summary>{% endif %}
+        <table>
+          <thead>
+            <tr>
+              <th>Variant</th>
+              <th>OS</th>
+              <th>Arch</th>
+              <th>Artifact</th>
+              <th>Size</th>
+              <th>SHA256<th>
+            </tr>
+          </thead>
+          <tbody>
+            {%- for variant, vassets in release.assets | groupby("_variant") %}
+            {%- set vloop = loop -%}
+            {%- for os, oassets in vassets | groupby("_os") -%}
+            {%- set oloop = loop -%}
+            {%- for arch, aassets in oassets | groupby("_arch") -%}
+            {%- set aloop = loop -%}
+            {% for asset in aassets %}
+              {%- if oloop.index0 + aloop.index0 == 0 %}
+            <tr class="variant-row">
+              <th rowspan="{{ vassets | count }}">{{ variant }}</th>
+              {%- else -%}
+            <tr>
+              {%- endif -%}
+              {%- if aloop.index0 == 0%}
+              <th rowspan="{{ oassets | count }}">{{ os }}</th>
+              {% endif -%}
+              <th>
+                <code>{{ arch }}</code>
+              </th>
+              <td>
+                <a href="{{ asset.browser_download_url }}"
+                   title="Download {{ variant }} {{ release.tag_name }} for {{ os }} on {{ arch }}">
+                  {{ asset.name }}
+                </a>
+              </td>
+              <td>{{ asset.size | filesizeformat }}</td>
+              <td>
+                <pre><code>{{ asset._sha256 }}</code></pre>
+              </td>
+            </tr>
+            {% endfor -%}
+            {% endfor -%}
+            {% endfor -%}
+            {% endfor -%}
+          </tbody>
+        </table>
+        {% if loop.index0 %}</summary>{% endif -%}
+      </article>
+      {% endfor -%}
+    </main>
+    <footer>
+      &copy; {{ year }} Miniforge Contributors
+    </footer>
+</html>


### PR DESCRIPTION
- for #76
- derived from https://nbviewer.jupyter.org/gist/bollwyvl/afb60e57c6f013ff445cfa46385a9b30#Preview
- [x] adds minimal, standalone HTML/CSS release page
- [x] adds minimal build/archive ci (no upload)

## potential follow-ons
- add pretty CLI generator a la [rapids](https://rapids.ai/start.html) or [psi4](https://psicode.org/installs/v132/)
- add os/arch filters
- add more narrative: _what's a Mambaforge?_
- add links to bill-of-materials #77
- RSS/ATOM feed