### PR TITLE
Update to mamba=0.7.12

### DIFF
--- a/Miniforge3/construct.yaml
+++ b/Miniforge3/construct.yaml
@@ -26,7 +26,7 @@ specs:
 {% endif %}
 
 {% if name.startswith("Mambaforge") %}
-  - mamba
+  - mamba 0.7.12
 {% endif %}
   - conda {{ version.split("-")[0] }}
 


### PR DESCRIPTION
We currently ship an older mamba release which has issues with private channels, updating to the latest release fixes these.

I added an explicit pin for the mamba version to improve reproducibility.