### PR TITLE
Add action to auto-update conda & mamba

### DIFF
--- a/.github/actions/autoupdate/environment.yml
+++ b/.github/actions/autoupdate/environment.yml
@@ -1,0 +1,7 @@
+name: miniconda-autoupdate
+channels:
+  - conda-forge
+  - nodefaults
+dependencies:
+  - packaging
+  - requests

--- a/.github/actions/autoupdate/update.py
+++ b/.github/actions/autoupdate/update.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+
+import re
+import requests
+from packaging import version
+
+def get_most_recent_version(name):
+    request = requests.get(
+        "https://api.anaconda.org/package/conda-forge/" + name
+    )
+    request.raise_for_status()
+
+    pkg = max(
+        request.json()["files"], key=lambda x: version.parse(x["version"])
+    )
+    return pkg["version"]
+
+mamba_version = get_most_recent_version("mamba")
+conda_version = get_most_recent_version("conda")
+
+with open("Miniforge3/construct.yaml", "r") as f:
+    content = f.read()
+
+# Replace conda version
+content = re.sub(r'MINIFORGE_VERSION",\s+"[\d.]+-(\d+)"', f"MINIFORGE_VERSION\", \"{conda_version}-\\1\"", content)
+
+# Replace mamba version
+content = re.sub(r"mamba [\d.]+$", f"mamba {mamba_version}", content, flags=re.M)
+
+with open("Miniforge3/construct.yaml", "w") as f:
+    f.write(content)

--- a/.github/actions/autoupdate/update.py
+++ b/.github/actions/autoupdate/update.py
@@ -16,13 +16,9 @@ def get_most_recent_version(name):
     return pkg["version"]
 
 mamba_version = get_most_recent_version("mamba")
-conda_version = get_most_recent_version("conda")
 
 with open("Miniforge3/construct.yaml", "r") as f:
     content = f.read()
-
-# Replace conda version
-content = re.sub(r'MINIFORGE_VERSION",\s+"[\d.]+-(\d+)"', f"MINIFORGE_VERSION\", \"{conda_version}-\\1\"", content)
 
 # Replace mamba version
 content = re.sub(r"mamba [\d.]+$", f"mamba {mamba_version}", content, flags=re.M)

--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -1,0 +1,32 @@
+name: Auto-update conda & mamba
+on:
+ schedule:
+   - cron: "0 */6 * * *"
+jobs:
+  createPullRequest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ssh-key: ${{ secrets.MINIFORGE_AUTOUPDATE_SSH_PRIVATE_KEY }}
+      - uses: conda-incubator/setup-miniconda@e23d871804685e8c52189e5bd45e9145019f10af
+        with:
+          miniforge-variant: Miniforge3
+          environment-file: .github/actions/autoupdate/environment.yml
+      - run: python .github/actions/autoupdate/update.py
+      - name: Create Pull Request
+        id: cpr
+        # This is the v3 tag but for security purposes we pin to the exact commit.
+        uses: peter-evans/create-pull-request@052fc72b4198ba9fbc81b818c6e1859f747d49a8
+        with:
+          commit-message: "Update conda/mamba version"
+          title: "Update conda/mamba version"
+          body: |
+            This PR was created by the autoupdate action as it detected that
+            either the conda or mamba version has changed and thus should be
+            updated in the configuration.
+
+            Due to limitations of Github Actions, you will need to close/reopen
+            the PR to get the actions running.
+          branch: autoupdate-action
+          delete-branch: true

--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -1,4 +1,4 @@
-name: Auto-update conda & mamba
+name: Auto-update mamba
 on:
  schedule:
    - cron: "0 */6 * * *"
@@ -19,12 +19,12 @@ jobs:
         # This is the v3 tag but for security purposes we pin to the exact commit.
         uses: peter-evans/create-pull-request@052fc72b4198ba9fbc81b818c6e1859f747d49a8
         with:
-          commit-message: "Update conda/mamba version"
-          title: "Update conda/mamba version"
+          commit-message: "Update mamba version"
+          title: "Update mamba version"
           body: |
             This PR was created by the autoupdate action as it detected that
-            either the conda or mamba version has changed and thus should be
-            updated in the configuration.
+            the mamba version has changed and thus should be updated
+            in the configuration.
 
             Due to limitations of Github Actions, you will need to close/reopen
             the PR to get the actions running.


### PR DESCRIPTION
Fixes #116 

This checks every 6h whether there is a new conda / mamba release and makes a PR that updates the `Miniforge3/construct.yaml` file.

Important things:

- Only opens a single PR and only if there are changes. If there is an open PR with conflicting changes, it won't do anything.
- If the PR was closed, it will delete the branch and recreate it with new commits.
- The commit will be pushed using a repo-specific deploy key. If the commit were pushed using the normal `${{ GITHUB_TOKEN }}`, CI wouldn't be triggered. As the deploy key is specific to this repo, it doesn't give anyone in the miniforge team more permissions that they would already have.
- I have added the deploy key to the repo and will also add it in the usual place in keybase.

See https://github.com/xhochy/miniforge-bot/pull/3 for a working example of this change.