### PR TITLE
Add dependabot config to update github action versions including pinned versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Keeping the Github actions updated via Dependabot. That especially helps when pinned action versions (sha1) are used instead of relativ tag versions.

Merging this PR creates the dependabot update PRs that can be seen here https://github.com/dbast/miniforge/pulls 

Dependabot was not able in the past to do pinned updates, but that got added for the same security reason as pinned versions are used here https://github.com/dependabot/dependabot-core/issues/2470 