### PR TITLE
Switch to tonistiigi/binfmt as qemu provider to support building on Apple M1

### DIFF
--- a/build_miniforge.sh
+++ b/build_miniforge.sh
@@ -10,8 +10,12 @@ set -ex
 
 # Check parameters
 ARCH=${ARCH:-aarch64}
+export TARGET_PLATFORM=${TARGET_PLATFORM:-linux-aarch64}
 DOCKER_ARCH=${DOCKER_ARCH:-arm64v8}
 DOCKERIMAGE=${DOCKERIMAGE:-condaforge/linux-anvil-aarch64}
+export MINIFORGE_NAME=${MINIFORGE_NAME:-Miniforge3}
+OS_NAME=${OS_NAME:-Linux}
+EXT=${EXT:-sh}
 export CONSTRUCT_ROOT=/construct
 
 echo "============= Create build directory ============="

--- a/build_miniforge.sh
+++ b/build_miniforge.sh
@@ -2,9 +2,10 @@
 # Build miniforge installers for Linux
 # on various architectures (aarch64, x86_64, ppc64le)
 # Notes:
-# It uses the qemu-user-static [1] emulator to enable
+# It uses the qemu emulator (see [1] or [2]) to enable
 # the use of containers images with different architectures than the host
 # [1]: https://github.com/multiarch/qemu-user-static/
+# [2]: https://github.com/tonistiigi/binfmt
 # See also: [setup-qemu-action](https://github.com/docker/setup-qemu-action)
 set -ex
 
@@ -24,8 +25,7 @@ chmod 777 build/
 
 echo "============= Enable QEMU ============="
 # Enable qemu in persistent mode
-docker run --rm --privileged multiarch/qemu-user-static \
-  --reset --credential yes --persistent yes
+docker run --privileged --rm tonistiigi/binfmt --install all
 
 echo "============= Build the installer ============="
 docker run --rm -v "$(pwd):/construct" \

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -2,6 +2,8 @@
 
 set -xe
 
+env | sort
+
 echo "***** Start: Building Miniforge installer *****"
 CONSTRUCT_ROOT="${CONSTRUCT_ROOT:-$PWD}"
 


### PR DESCRIPTION
The mentioned https://github.com/docker/setup-qemu-action also uses the tonistiigi/binfmt image. It supports not only linux/amd64 as emulation host, but also all the OS/ARCH combination it can emulate, see https://hub.docker.com/r/tonistiigi/binfmt/tags?page=1&ordering=last_updated

It also seems to be better maintained (regarding working qemu versions and qemu updates) and has now higher pull numbers [![Docker Pulls](https://img.shields.io/docker/pulls/tonistiigi/binfmt.svg?logo=docker)](https://hub.docker.com/r/tonistiigi/binfmt/) (vs [![Docker Hub](https://img.shields.io/docker/pulls/multiarch/qemu-user-static.svg?logo=docker)](https://hub.docker.com/r/multiarch/qemu-user-static/))

Also set defaults for all required environment variables in build_miniforge.sh:
* The variables are exported in the same order as they are set by ci.yml.
* Some variables are exported so that `docker run -e $VARIABLE ..` gets them.
* Also print environment variables at the beginning of build.sh for better debuggability.

This enables running build_miniforge.sh on Apple M1 without any additional setup or setting any variables (duration=1m55sec, testing included).