### PR TITLE
Update test matrix - Add Debian 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ After construction on the CI, the installer is tested against a range of distrib
 
 - Centos 7
 - Debian Buster (10)
+- Debian Bullseye (11)
 - Ubuntu 16.04 ([LTS](https://ubuntu.com/about/release-cycle))
 - Ubuntu 18.04 ([LTS](https://ubuntu.com/about/release-cycle))
 - Ubuntu 20.04 ([LTS](https://ubuntu.com/about/release-cycle))

--- a/build_miniforge.sh
+++ b/build_miniforge.sh
@@ -36,7 +36,7 @@ docker run --rm -v "$(pwd):/construct" \
 cp "build/${MINIFORGE_NAME}-"*"-${OS_NAME}-${ARCH}.${EXT}" "build/${MINIFORGE_NAME}-${OS_NAME}-${ARCH}.${EXT}"
 
 echo "============= Test the installer ============="
-for TEST_IMAGE_NAME in "ubuntu:21.04" "ubuntu:20.04" "ubuntu:18.04" "ubuntu:16.04" "centos:7" "debian:buster"; do
+for TEST_IMAGE_NAME in "ubuntu:21.04" "ubuntu:20.04" "ubuntu:18.04" "ubuntu:16.04" "centos:7" "debian:bullseye" "debian:buster"; do
   echo "============= Test installer on ${TEST_IMAGE_NAME} ============="
   docker run --rm -v "$(pwd):/construct" -e CONSTRUCT_ROOT \
     "${DOCKER_ARCH}/${TEST_IMAGE_NAME}" /construct/scripts/test.sh


### PR DESCRIPTION
Debian Bullseye (11) was released on August 14th 2021.
~~Ubuntu 16.04 reached its end of five-year LTS window on April 30th 2021.~~