### PR TITLE
Update to conda 22.9 with tests for boa compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,6 +195,7 @@ jobs:
         DOCKERIMAGE: ${{ matrix.DOCKERIMAGE }}
         DOCKER_ARCH: ${{ matrix.DOCKER_ARCH }}
         TARGET_PLATFORM: ${{ matrix.TARGET_PLATFORM }}
+        TEST_IMAGE_NAMES: ${{ matrix.TEST_IMAGE_NAMES }}
       run: |
         if [[ "$GITHUB_REF" == refs/tags/* ]]; then
           export MINIFORGE_VERSION=${GITHUB_REF##*/};

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,9 +174,6 @@ jobs:
             # for as a compatibility
             # xref https://github.com/conda-forge/miniforge/pull/361
             TEST_IMAGE_NAMES: "centos:7"
-            # It turns out, tat on this particular image, even a single test
-            # for compatibility does not finish in time.
-            TEST_CONDA_MAMBA_BOA_COMPATIBILITY: "no"
 
     steps:
     - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,11 @@ jobs:
             DOCKERIMAGE: condaforge/linux-anvil-aarch64
             MINIFORGE_NAME: "Mambaforge-pypy3"
             OS_NAME: "Linux"
+            # Reduce the test matrix because the builds timeouts on emulated architectures
+            # The time consuming operation is an attempt a full solve of conda/mamba/boa
+            # for as a compatibility
+            # xref https://github.com/conda-forge/miniforge/pull/361
+            TEST_IMAGE_NAMES: "ubuntu:22.04"
 
           - os: ubuntu-latest
             ARCH: x86_64
@@ -164,6 +169,14 @@ jobs:
             DOCKERIMAGE: condaforge/linux-anvil-ppc64le
             MINIFORGE_NAME: "Mambaforge-pypy3"
             OS_NAME: "Linux"
+            # Reduce the test matrix because the builds timeouts on emulated architectures
+            # The time consuming operation is an attempt a full solve of conda/mamba/boa
+            # for as a compatibility
+            # xref https://github.com/conda-forge/miniforge/pull/361
+            TEST_IMAGE_NAMES: "centos:7"
+            # It turns out, tat on this particular image, even a single test
+            # for compatibility does not finish in time.
+            TEST_CONDA_MAMBA_BOA_COMPATIBILITY: "no"
 
     steps:
     - name: Checkout code

--- a/Miniforge3/construct.yaml
+++ b/Miniforge3/construct.yaml
@@ -1,4 +1,4 @@
-{% set version = os.environ.get("MINIFORGE_VERSION", "4.14.0-1") %}
+{% set version = os.environ.get("MINIFORGE_VERSION", "22.9.0-1") %}
 {% set name = os.environ.get("MINIFORGE_NAME", "Miniforge3") %}
 
 name: {{ name }}

--- a/build_miniforge.sh
+++ b/build_miniforge.sh
@@ -17,6 +17,8 @@ DOCKERIMAGE=${DOCKERIMAGE:-condaforge/linux-anvil-aarch64}
 export MINIFORGE_NAME=${MINIFORGE_NAME:-Miniforge3}
 OS_NAME=${OS_NAME:-Linux}
 EXT=${EXT:-sh}
+TEST_IMAGE_NAMES=${TEST_IMAGE_NAMES:-ubuntu:22.04 ubuntu:20.04 ubuntu:18.04 ubuntu:16.04 centos:7 debian:bullseye debian:buster}
+TEST_CONDA_MAMBA_BOA_COMPATIBILITY=${TEST_CONDA_MAMBA_BOA_COMPATIBILITY:-yes}
 export CONSTRUCT_ROOT=/construct
 
 echo "============= Create build directory ============="
@@ -33,8 +35,10 @@ docker run --rm -v "$(pwd):/construct" \
   "${DOCKERIMAGE}" /construct/scripts/build.sh
 
 echo "============= Test the installer ============="
-for TEST_IMAGE_NAME in "ubuntu:22.04" "ubuntu:20.04" "ubuntu:18.04" "ubuntu:16.04" "centos:7" "debian:bullseye" "debian:buster"; do
+for TEST_IMAGE_NAME in ${TEST_IMAGE_NAMES}; do
   echo "============= Test installer on ${TEST_IMAGE_NAME} ============="
-  docker run --rm -v "$(pwd):/construct" -e CONSTRUCT_ROOT \
+  docker run --rm \
+    -v "$(pwd):${CONSTRUCT_ROOT}" -e CONSTRUCT_ROOT \
+    -e TEST_CONDA_MAMBA_BOA_COMPATIBILITY \
     "${DOCKER_ARCH}/${TEST_IMAGE_NAME}" /construct/scripts/test.sh
 done

--- a/build_miniforge.sh
+++ b/build_miniforge.sh
@@ -18,7 +18,6 @@ export MINIFORGE_NAME=${MINIFORGE_NAME:-Miniforge3}
 OS_NAME=${OS_NAME:-Linux}
 EXT=${EXT:-sh}
 TEST_IMAGE_NAMES=${TEST_IMAGE_NAMES:-ubuntu:22.04 ubuntu:20.04 ubuntu:18.04 ubuntu:16.04 centos:7 debian:bullseye debian:buster}
-TEST_CONDA_MAMBA_BOA_COMPATIBILITY=${TEST_CONDA_MAMBA_BOA_COMPATIBILITY:-yes}
 export CONSTRUCT_ROOT=/construct
 
 echo "============= Create build directory ============="
@@ -39,6 +38,5 @@ for TEST_IMAGE_NAME in ${TEST_IMAGE_NAMES}; do
   echo "============= Test installer on ${TEST_IMAGE_NAME} ============="
   docker run --rm \
     -v "$(pwd):${CONSTRUCT_ROOT}" -e CONSTRUCT_ROOT \
-    -e TEST_CONDA_MAMBA_BOA_COMPATIBILITY \
     "${DOCKER_ARCH}/${TEST_IMAGE_NAME}" /construct/scripts/test.sh
 done

--- a/build_miniforge_osx.sh
+++ b/build_miniforge_osx.sh
@@ -4,20 +4,20 @@ set -e
 set -x
 
 echo "Installing a fresh version of Miniforge3."
-# Keep variable names in sync with 
+# Keep variable names in sync with
 # https://github.com/conda-forge/docker-images/blob/main/scripts/run_commands
 miniforge_arch="$(uname -m)"
-miniforge_version="4.10.3-10"
+miniforge_version="4.14.0-0"
 condapkg="https://github.com/conda-forge/miniforge/releases/download/${miniforge_version}/Mambaforge-${miniforge_version}-MacOSX-${miniforge_arch}.sh"
 if [ "$(uname -m)" = "x86_64" ]; then
-   conda_chksum="7c44259a0982cd3ef212649678af5f0dd4e0bb7306e8fffc93601dd1d739ec0b"
+   conda_checksum="949f046b4404cc8e081807b048050e6642d8db5520c20d5158a7ef721fbf76c5"
 elif [ "$(uname -m)" = "arm64" ]; then
-   conda_chksum="72bc86612ab9435915b616c2edb076737cbabe2c33fd684d58c2f9ae72e1957c"
+   conda_checksum="35d05a65e19b8e5d596964936ddd6023ae66d664a25ba291a52fec18f06a73b6"
 else
    exit 1
 fi
-curl -s -L "$condapkg" > miniconda.sh
-openssl sha256 miniconda.sh | grep $conda_chksum
+curl -s -L "$condapkg" -o miniconda.sh
+openssl sha256 miniconda.sh | grep $conda_checksum
 
 bash miniconda.sh -b -p ~/conda
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -12,16 +12,17 @@ cd "${CONSTRUCT_ROOT}"
 # Constructor should be latest for non-native building
 # See https://github.com/conda/constructor
 echo "***** Install constructor *****"
-conda install -y "constructor>=3.3.1" jinja2 curl libarchive -c conda-forge --override-channels
-
+conda install --yes \
+    --channel conda-forge --override-channels \
+    jinja2 curl libarchive \
+    "constructor>=3.3.1"
 if [[ "$(uname)" == "Darwin" ]]; then
-    conda install -y coreutils -c conda-forge --override-channels
+    conda install --yes coreutils --channel conda-forge --override-channels
 fi
 # shellcheck disable=SC2154
 if [[ "${TARGET_PLATFORM}" == win-* ]]; then
-    conda install -y "nsis=3.01" -c conda-forge --override-channels
+    conda install --yes "nsis=3.01" --channel conda-forge --override-channels
 fi
-# pip install git+git://github.com/conda/constructor@3.3.1#egg=constructor --force --no-deps
 conda list
 
 echo "***** Make temp directory *****"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -7,6 +7,7 @@ echo "***** Start: Testing Miniforge installer *****"
 export CONDA_PATH="${HOME}/miniforge"
 
 CONSTRUCT_ROOT="${CONSTRUCT_ROOT:-${PWD}}"
+TEST_CONDA_MAMBA_BOA_COMPATIBILITY=${TEST_CONDA_MAMBA_BOA_COMPATIBILITY:-yes}
 
 cd "${CONSTRUCT_ROOT}"
 
@@ -45,7 +46,7 @@ if [[ "$(uname)" == MINGW* ]]; then
   conda.exe install r-base --yes --quiet
   conda.exe list
 
-  if [[ "${INSTALLER_NAME}" == "Mambaforge" ]]; then
+  if [[ "${INSTALLER_NAME}" == "Mambaforge" ]] && [[ "${TEST_CONDA_MAMBA_BOA_COMPATIBILITY}" == "yes" ]]; then
     echo "***** Mambaforge detected. Checking for boa compatibility *****"
     mamba_version_start=$(mamba --version | grep mamba | cut -d ' ' -f 2)
     mamba.exe install boa --yes
@@ -66,14 +67,13 @@ else
   conda info
   conda list
 
-  if [[ "${INSTALLER_NAME}" == "Mambaforge" ]]; then
+  if [[ "${INSTALLER_NAME}" == "Mambaforge" ]] && [[ "${TEST_CONDA_MAMBA_BOA_COMPATIBILITY}" == "yes" ]]; then
     echo "***** Mambaforge detected. Checking for boa compatibility *****"
     implementation=$(python -c "import platform; print(platform.python_implementation().lower())")
     major_minor_version=$(python -c 'import sys; print(f"{sys.version_info[0]}.{sys.version_info[1]}")')
     mamba_version_start=$(mamba --version | grep mamba | cut -d ' ' -f 2)
     mamba info
-    mamba install "mamba=${mamba_version_start}" "python=${major_minor_version}.*=*_${implementation}" boa --yes --verbose || \
-        (wc -l /root/miniforge/pkgs/cache/09cdf8bf.json && cat /root/miniforge/pkgs/cache/09cdf8bf.json && exit 1)
+    mamba install "mamba=${mamba_version_start}" "python=${major_minor_version}.*=*_${implementation}" boa --yes
     mamba_version_end=$(mamba --version | grep mamba | cut -d ' ' -f 2)
     if [[ "${mamba_version_start}" != "${mamba_version_end}" ]]; then
         echo "mamba version changed from ${mamba_version_start} to ${mamba_version_end}"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -65,13 +65,15 @@ else
   echo "***** Print conda info *****"
   conda info
   conda list
-  conda clean --yes --index-cache
 
   if [[ "${INSTALLER_NAME}" == "Mambaforge" ]]; then
     echo "***** Mambaforge detected. Checking for boa compatibility *****"
+    implementation=$(python -c "import platform; print(platform.python_implementation().lower())")
+    major_minor_version=$(python -c 'import sys; print(f"{sys.version_info[0]}.{sys.version_info[1]}")')
     mamba_version_start=$(mamba --version | grep mamba | cut -d ' ' -f 2)
     mamba info
-    mamba install "mamba=${mamba_version_start}" boa --yes
+    mamba install "mamba=${mamba_version_start}" "python=${major_minor_version}.*=*_${implementation}" boa --yes --verbose || \
+        (wc -l /root/miniforge/pkgs/cache/09cdf8bf.json && cat /root/miniforge/pkgs/cache/09cdf8bf.json && exit 1)
     mamba_version_end=$(mamba --version | grep mamba | cut -d ' ' -f 2)
     if [[ "${mamba_version_start}" != "${mamba_version_end}" ]]; then
         echo "mamba version changed from ${mamba_version_start} to ${mamba_version_end}"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -7,7 +7,6 @@ echo "***** Start: Testing Miniforge installer *****"
 export CONDA_PATH="${HOME}/miniforge"
 
 CONSTRUCT_ROOT="${CONSTRUCT_ROOT:-${PWD}}"
-TEST_CONDA_MAMBA_BOA_COMPATIBILITY=${TEST_CONDA_MAMBA_BOA_COMPATIBILITY:-yes}
 
 cd "${CONSTRUCT_ROOT}"
 
@@ -46,7 +45,7 @@ if [[ "$(uname)" == MINGW* ]]; then
   conda.exe install r-base --yes --quiet
   conda.exe list
 
-  if [[ "${INSTALLER_NAME}" == "Mambaforge" ]] && [[ "${TEST_CONDA_MAMBA_BOA_COMPATIBILITY}" == "yes" ]]; then
+  if [[ "${INSTALLER_NAME}" == "Mambaforge" ]]; then
     echo "***** Mambaforge detected. Checking for boa compatibility *****"
     mamba_version_start=$(mamba --version | grep mamba | cut -d ' ' -f 2)
     mamba.exe install boa --yes
@@ -67,7 +66,7 @@ else
   conda info
   conda list
 
-  if [[ "${INSTALLER_NAME}" == "Mambaforge" ]] && [[ "${TEST_CONDA_MAMBA_BOA_COMPATIBILITY}" == "yes" ]]; then
+  if [[ "${INSTALLER_NAME}" == "Mambaforge" ]]; then
     echo "***** Mambaforge detected. Checking for boa compatibility *****"
     implementation=$(python -c "import platform; print(platform.python_implementation().lower())")
     major_minor_version=$(python -c 'import sys; print(f"{sys.version_info[0]}.{sys.version_info[1]}")')


### PR DESCRIPTION
- Explicit test for conda/mamba/boa compatibility for Mambaforge
- Reduced test matrix for Mambaforge-pypy3 on emulated architectures (aarch64 and ppc64le) -- ensures CI pass in time?
- Updated micromamba on osx

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
