### PR TITLE
Update to conda 22.9 without tests for boa

### DIFF
--- a/Miniforge3/construct.yaml
+++ b/Miniforge3/construct.yaml
@@ -1,4 +1,4 @@
-{% set version = os.environ.get("MINIFORGE_VERSION", "4.14.0-2") %}
+{% set version = os.environ.get("MINIFORGE_VERSION", "22.9.0-1") %}
 {% set name = os.environ.get("MINIFORGE_NAME", "Miniforge3") %}
 
 name: {{ name }}

--- a/Miniforge3/construct.yaml
+++ b/Miniforge3/construct.yaml
@@ -1,4 +1,4 @@
-{% set version = os.environ.get("MINIFORGE_VERSION", "4.14.0-1") %}
+{% set version = os.environ.get("MINIFORGE_VERSION", "4.14.0-2") %}
 {% set name = os.environ.get("MINIFORGE_NAME", "Miniforge3") %}
 
 name: {{ name }}

--- a/build_miniforge_osx.sh
+++ b/build_miniforge_osx.sh
@@ -4,20 +4,20 @@ set -e
 set -x
 
 echo "Installing a fresh version of Miniforge3."
-# Keep variable names in sync with 
+# Keep variable names in sync with
 # https://github.com/conda-forge/docker-images/blob/main/scripts/run_commands
 miniforge_arch="$(uname -m)"
-miniforge_version="4.10.3-10"
+miniforge_version="4.14.0-0"
 condapkg="https://github.com/conda-forge/miniforge/releases/download/${miniforge_version}/Mambaforge-${miniforge_version}-MacOSX-${miniforge_arch}.sh"
 if [ "$(uname -m)" = "x86_64" ]; then
-   conda_chksum="7c44259a0982cd3ef212649678af5f0dd4e0bb7306e8fffc93601dd1d739ec0b"
+   conda_checksum="949f046b4404cc8e081807b048050e6642d8db5520c20d5158a7ef721fbf76c5"
 elif [ "$(uname -m)" = "arm64" ]; then
-   conda_chksum="72bc86612ab9435915b616c2edb076737cbabe2c33fd684d58c2f9ae72e1957c"
+   conda_checksum="35d05a65e19b8e5d596964936ddd6023ae66d664a25ba291a52fec18f06a73b6"
 else
    exit 1
 fi
-curl -s -L "$condapkg" > miniconda.sh
-openssl sha256 miniconda.sh | grep $conda_chksum
+curl -s -L "$condapkg" -o miniconda.sh
+openssl sha256 miniconda.sh | grep $conda_checksum
 
 bash miniconda.sh -b -p ~/conda
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -18,7 +18,6 @@ else
    EXT="sh";
 fi
 INSTALLER_PATH=$(find build/ -name "*forge*.${EXT}" | head -n 1)
-INSTALLER_NAME=$(basename "${INSTALLER_PATH}" | cut -d "-" -f 1)
 
 echo "***** Run the installer *****"
 chmod +x "${INSTALLER_PATH}"
@@ -45,16 +44,6 @@ if [[ "$(uname)" == MINGW* ]]; then
   conda.exe install r-base --yes --quiet
   conda.exe list
 
-  if [[ "${INSTALLER_NAME}" == "Mambaforge" ]]; then
-    echo "***** Mambaforge detected. Checking for boa compatibility *****"
-    mamba_version_start=$(mamba --version | grep mamba | cut -d ' ' -f 2)
-    mamba.exe install boa --yes
-    mamba_version_end=$(mamba --version | grep mamba | cut -d ' ' -f 2)
-    if [[ "${mamba_version_start}" != "${mamba_version_end}" ]]; then
-        echo "mamba version changed from ${mamba_version_start} to ${mamba_version_end}"
-        exit 1
-    fi
-  fi
 else
   bash "${INSTALLER_PATH}" -b -p "${CONDA_PATH}"
 
@@ -65,20 +54,6 @@ else
   echo "***** Print conda info *****"
   conda info
   conda list
-  # conda clean --yes --index-cache
-
-  if [[ "${INSTALLER_NAME}" == "Mambaforge" ]]; then
-    echo "***** Mambaforge detected. Checking for boa compatibility *****"
-    mamba_version_start=$(mamba --version | grep mamba | cut -d ' ' -f 2)
-    mamba info
-    mamba install "mamba=${mamba_version_start}" boa --yes
-    mamba_version_end=$(mamba --version | grep mamba | cut -d ' ' -f 2)
-    if [[ "${mamba_version_start}" != "${mamba_version_end}" ]]; then
-        echo "mamba version changed from ${mamba_version_start} to ${mamba_version_end}"
-        exit 1
-    fi
-
-  fi
 fi
 
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -65,7 +65,7 @@ else
   echo "***** Print conda info *****"
   conda info
   conda list
-  conda clean --yes --index-cache
+  # conda clean --yes --index-cache
 
   if [[ "${INSTALLER_NAME}" == "Mambaforge" ]]; then
     echo "***** Mambaforge detected. Checking for boa compatibility *****"


### PR DESCRIPTION
I'm just not sure I can understand why the boa tests are failing. It seems like a caching issue.


Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
