### PR TITLE
Add VirusTotal scanning to releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,12 @@
 name: Build miniforge
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  release:
+    # published = released or prereleased
+    types: [published]
 
 jobs:
   build:
@@ -234,4 +241,21 @@ jobs:
         tag: ${{ github.ref }}
         overwrite: true
         file_glob: true
+      if: startsWith(github.ref, 'refs/tags/')
+
+  scan:
+    name: VirusTotal Scan
+    needs: [build]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+    - name: Scan
+      uses: crazy-max/ghaction-virustotal@v3
+      with:
+        vt_api_key: ${{ secrets.VT_API_KEY }}
+        update_release_body: true
+        request_rate: 4
+        files: |
+          .sh$
+          .exe$
       if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
This adds scanning released installers with [VirusTotal](virustotal.com), which currently scans with 61 different Virus/Malware Scanners.

It is neither blocking a release nor marking it red/green, instead a collapsible is added to the release description containing all the links to the VirusTotal results, see e.g. the releases made in my forked repo https://github.com/dbast/miniforge/releases .. The links even have a re-scan button without the need to re-upload anything as they cache uploads.

This is both for the sceptical people, who want to have installers scanned before using them AND also for everybody else to check if there are any false positives that could block the installers on machines with active scanners. While any true positive findings are not really expected, really proofing it is some value as installers are the most common way to bootstrap installations (besides micromamba / conda-packed envs without installers).

The VirusTotal scan API can be used freely by OpenSource Projects with a rate limit of 4 lookups / minute (Monthly quota: 15.50 K lookups / month). It requires a core/miniforge developer to sign up there, get the API key from https://www.virustotal.com/gui/my-apikey and adding it to the repo secrets called `VT_API_KEY` (I can also provide my API key, if that is of help).

The implementation required changing the ci.yml workflow triggers as the `crazy-max/ghaction-virustotal@v3` action relies on the `release` trigger to work.