### PR TITLE
Resolve action deprecation warnings

### DIFF
--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -9,11 +9,15 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ssh-key: ${{ secrets.MINIFORGE_AUTOUPDATE_SSH_PRIVATE_KEY }}
-      - uses: conda-incubator/setup-miniconda@35d1405e78aa3f784fe3ce9a2eb378d5eeb62169
-        with:
-          miniforge-variant: Miniforge3
-          environment-file: .github/actions/autoupdate/environment.yml
-      - run: python .github/actions/autoupdate/update.py
+      - name: Setup
+        run: |
+          source $CONDA/etc/profile.d/conda.sh
+          conda env create -f .github/actions/autoupdate/environment.yml
+      - name: Update
+        run: |
+          source $CONDA/etc/profile.d/conda.sh
+          conda activate miniconda-autoupdate
+          python .github/actions/autoupdate/update.py
       - name: Create Pull Request
         id: cpr
         # This is the v3 tag but for security purposes we pin to the exact commit.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,11 +179,6 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
 
-    - uses: conda-incubator/setup-miniconda@35d1405e78aa3f784fe3ce9a2eb378d5eeb62169
-      with:
-        miniconda-version: "latest"
-      if: contains(matrix.OS_NAME, 'Windows')
-
     - name: Build and test miniforge
       env:
         ARCH: ${{ matrix.ARCH }}
@@ -208,7 +203,7 @@ jobs:
         if [[ "$OS_NAME" == "Windows" ]]; then
           export EXT=exe
           echo "WINDIR:$WINDIR"
-          source /c/Miniconda3/Scripts/activate;
+          source /c/Miniconda/Scripts/activate;
           source build_miniforge_win.sh;
         fi
         # Copy for latest release

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,9 +8,14 @@ jobs:
         shell: bash -l {0}
     steps:
       - uses: actions/checkout@v3
-      - uses: conda-incubator/setup-miniconda@35d1405e78aa3f784fe3ce9a2eb378d5eeb62169
-      - run: python -m pip install -r docs/requirements.txt
-      - run: python docs/releases.py
+      - name: setup
+        run: |
+          source $CONDA/etc/profile.d/conda.sh
+          python -m pip install -r docs/requirements.txt
+      - name: render
+        run: |
+          source $CONDA/etc/profile.d/conda.sh
+          python docs/releases.py
       - uses: actions/upload-artifact@v3
         with:
           path: build/docs

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,13 +8,9 @@ jobs:
         shell: bash -l {0}
     steps:
       - uses: actions/checkout@v3
-      - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@v2
-      - name: Install dependencies
-        run: |
-          conda install -c conda-forge shellcheck
       - name: Shellcheck
         run: |
+          # shellcheck is pre-install on the action runners
           echo "::add-matcher::.github/shellcheck-matcher.json"
           shellcheck --format=gcc $(find . -iname "*.sh")
           echo "::remove-matcher owner=shellcheck::"


### PR DESCRIPTION
Current warnings are:
* Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: conda-incubator/setup-miniconda, svenstaro/upload-release-action
* The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

The warnings are caused by `conda-incubator/setup-miniconda`/`svenstaro/upload-release-action` and have proposed fixes:
* https://github.com/conda-incubator/setup-miniconda/pull/249
* https://github.com/conda-incubator/setup-miniconda/pull/252
* https://github.com/svenstaro/upload-release-action/pull/83

While the proposed fixes are fine, the warnings caused by `conda-incubator/setup-miniconda` can be avoided by using the Github runner pre-installed miniconda, which also saves some seconds for each action run (see also https://github.com/actions/runner-images/search?q=miniconda where the runners are defined)