### PR TITLE
Use temporary default GITHUB_TOKEN for update PRs

### DIFF
--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -2,13 +2,18 @@ name: Auto-update mamba
 on:
  schedule:
    - cron: "0 */6 * * *"
+
+# set permissions of temporary default GITHUB_TOKEN token to be able to create PRs,
+# without the need of ssh keys or personal access tokens
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   createPullRequest:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-        with:
-          ssh-key: ${{ secrets.MINIFORGE_AUTOUPDATE_SSH_PRIVATE_KEY }}
       - uses: conda-incubator/setup-miniconda@35d1405e78aa3f784fe3ce9a2eb378d5eeb62169
         with:
           miniforge-variant: Miniforge3


### PR DESCRIPTION
By extending the scope of the per run temporaray default GitHub action token `GITHUB_TOKEN` the need of using ssh keys for cloning/pushing updates is eliminated.

So no need to manage an extra ssh anymore and this is also a security improvement as ssh keys could be leaked, while the token is only valid during the workflow runs.

This got possible via the changes announced here a while ago: https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/