### PR TITLE
Switch to constructor >=3.4.2

### DIFF
--- a/Miniforge3/construct.yaml
+++ b/Miniforge3/construct.yaml
@@ -27,7 +27,7 @@ specs:
 {% endif %}
 
 {% if name.startswith("Mambaforge") %}
-  - mamba 1.1.0
+  - mamba 1.2.0
 {% endif %}
   - conda {{ version.split("-")[0] }}
 

--- a/Miniforge3/construct.yaml
+++ b/Miniforge3/construct.yaml
@@ -32,4 +32,7 @@ specs:
   - conda {{ version.split("-")[0] }}
 
   - pip
+  # Unpin setuptools when the issue below is resolved
+  # https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/3973
+  - setuptools 65.*
   - miniforge_console_shortcut 1.*  # [win]

--- a/Miniforge3/construct.yaml
+++ b/Miniforge3/construct.yaml
@@ -27,7 +27,7 @@ specs:
 {% endif %}
 
 {% if name.startswith("Mambaforge") %}
-  - mamba 1.2.0
+  - mamba 1.1.0
 {% endif %}
   - conda {{ version.split("-")[0] }}
 

--- a/Miniforge3/construct.yaml
+++ b/Miniforge3/construct.yaml
@@ -1,4 +1,4 @@
-{% set version = os.environ.get("MINIFORGE_VERSION", "22.9.0-3") %}
+{% set version = os.environ.get("MINIFORGE_VERSION", "22.11.1-0") %}
 {% set name = os.environ.get("MINIFORGE_NAME", "Miniforge3") %}
 
 name: {{ name }}

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -15,7 +15,7 @@ echo "***** Install constructor *****"
 conda install --yes \
     --channel conda-forge --override-channels \
     jinja2 curl libarchive \
-    "constructor>=3.3.1"
+    "constructor==3.3.1"
 if [[ "$(uname)" == "Darwin" ]]; then
     conda install --yes coreutils --channel conda-forge --override-channels
 fi

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -15,7 +15,7 @@ echo "***** Install constructor *****"
 conda install --yes \
     --channel conda-forge --override-channels \
     jinja2 curl libarchive \
-    "constructor==3.3.1"
+    "constructor>=3.4.1"
 if [[ "$(uname)" == "Darwin" ]]; then
     conda install --yes coreutils --channel conda-forge --override-channels
 fi

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -19,10 +19,6 @@ conda install --yes \
 if [[ "$(uname)" == "Darwin" ]]; then
     conda install --yes coreutils --channel conda-forge --override-channels
 fi
-# shellcheck disable=SC2154
-if [[ "${TARGET_PLATFORM}" == win-* ]]; then
-    conda install --yes "nsis=3.01" --channel conda-forge --override-channels
-fi
 conda list
 
 echo "***** Make temp directory *****"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -15,7 +15,7 @@ echo "***** Install constructor *****"
 conda install --yes \
     --channel conda-forge --override-channels \
     jinja2 curl libarchive \
-    "constructor>=3.4.1"
+    "constructor>=3.4.2"
 if [[ "$(uname)" == "Darwin" ]]; then
     conda install --yes coreutils --channel conda-forge --override-channels
 fi


### PR DESCRIPTION
~~The next soon to be [happening](https://github.com/conda/constructor/issues/577) constructor release contains lots of [changes](https://github.com/conda/constructor/tree/main/news).~~  Released

~~Pinning the current stable version allows to later consciously unpin it again, while the unpin PR artefacts can serve as test point to check that all the installers continue to work fine, before tagging a new release.~~

Requiring constructor ~~>=3.4.1~~ >=3.4.2 to see how it builds.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
