### PR TITLE
Fixup constructor bug in 22.11.1-0 UNIX installers.

### DIFF
--- a/Miniforge3/construct.yaml
+++ b/Miniforge3/construct.yaml
@@ -16,8 +16,11 @@ write_condarc: True
 # and keep the same with Miniconda
 keep_pkgs: True
 license_file: ../LICENSE
-# Blocked until https://github.com/mamba-org/mamba/issues/1497 is fixed
-# transmute_file_type: .conda
+
+# During the interactive installation, these variables are checked.
+# During batch installation, conda is never initialized
+initialize_conda: True
+initialize_by_default: True
 
 specs:
 {% if name.endswith("pypy3") %}

--- a/Miniforge3/construct.yaml
+++ b/Miniforge3/construct.yaml
@@ -1,4 +1,4 @@
-{% set version = os.environ.get("MINIFORGE_VERSION", "22.11.1-0") %}
+{% set version = os.environ.get("MINIFORGE_VERSION", "22.11.1-1") %}
 {% set name = os.environ.get("MINIFORGE_NAME", "Miniforge3") %}
 
 name: {{ name }}

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -56,7 +56,23 @@ if [[ "$(uname)" == MINGW* ]]; then
     fi
   fi
 else
-  bash "${INSTALLER_PATH}" -b -p "${CONDA_PATH}"
+  # Test one of our installers in batch mode
+  if [[ "${INSTALLER_NAME}" == "Mambaforge" ]]; then
+    bash "${INSTALLER_PATH}" -b -p "${CONDA_PATH}"
+  # And the other in interactive mode
+  else
+    # Test interactive install. The install will ask the user to
+    # read the EULA
+    # then accept
+    # Then specify the path
+    # Then whether or not they want to initialize conda
+    cat <<EOF | bash "${INSTALLER_PATH}"
+
+yes
+${CONDA_PATH}
+no
+EOF
+  fi
 
   echo "***** Setup conda *****"
   # shellcheck disable=SC1091


### PR DESCRIPTION
cc @dbast 

Fixes: https://github.com/conda-forge/miniforge/issues/413
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
