### PR TITLE
Do not initialize conda by default but workaround 3.4.2

### DIFF
--- a/Miniforge3/construct.yaml
+++ b/Miniforge3/construct.yaml
@@ -1,4 +1,4 @@
-{% set version = os.environ.get("MINIFORGE_VERSION", "22.11.1-1") %}
+{% set version = os.environ.get("MINIFORGE_VERSION", "22.11.1-2") %}
 {% set name = os.environ.get("MINIFORGE_NAME", "Miniforge3") %}
 
 name: {{ name }}
@@ -20,7 +20,7 @@ license_file: ../LICENSE
 # During the interactive installation, these variables are checked.
 # During batch installation, conda is never initialized
 initialize_conda: True
-initialize_by_default: True
+initialize_by_default: False
 
 specs:
 {% if name.endswith("pypy3") %}


### PR DESCRIPTION
@dbast if you could help identify the flags that would recreate the old behavior that would be great.

I think I got them right this time.
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
