### PR TITLE
Pin no longer needed for setuptools

### DIFF
--- a/Miniforge3/construct.yaml
+++ b/Miniforge3/construct.yaml
@@ -35,7 +35,4 @@ specs:
   - conda {{ version.split("-")[0] }}
 
   - pip
-  # Unpin setuptools when the issue below is resolved
-  # https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/3973
-  - setuptools 65.*
   - miniforge_console_shortcut 1.*  # [win]


### PR DESCRIPTION
https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/3973 is now resolved

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
