### PR TITLE
get conda-standalone from canary (DNM)

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -14,7 +14,8 @@ echo "***** Install constructor *****"
 mamba install --yes \
     --channel conda-forge --override-channels \
     jinja2 curl libarchive \
-    "constructor>=3.4.5"
+    "constructor>=3.4.5" \
+    "conda-canary/label/dev::conda-standalone"
 
 if [[ "$(uname)" == "Darwin" ]]; then
     mamba install --yes \


### PR DESCRIPTION
Trying newly cut conda-standalone 23.7.2 before releasing in main channel.

Do not merge, sorry for the noise!