### PR TITLE
 Update to conda 23.10 and mamba 1.5.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,7 +194,7 @@ jobs:
         miniforge-version: "latest"
         miniforge-variant: Mambaforge
         use-mamba: true
-      if: contains(matrix.OS_NAME, 'Windows')
+      if: ${{ ! contains(matrix.OS_NAME, 'Linux') }}
 
     - name: Build and test miniforge
       env:

--- a/Miniforge3/construct.yaml
+++ b/Miniforge3/construct.yaml
@@ -1,7 +1,7 @@
 {% set name = os.environ.get("MINIFORGE_NAME", "Miniforge3") %}
-{% set version = os.environ.get("MINIFORGE_VERSION", "23.3.1-0") %}
-{% set conda_libmamba_solver_version = "23.3.0"%}
-{% set mamba_version = "1.4.2"%}
+{% set version = os.environ.get("MINIFORGE_VERSION", "23.7.4-0") %}
+{% set conda_libmamba_solver_version = "23.7.4"%}
+{% set mamba_version = "1.5.1"%}
 
 name: {{ name }}
 version: {{ version }}

--- a/Miniforge3/construct.yaml
+++ b/Miniforge3/construct.yaml
@@ -1,6 +1,6 @@
 {% set name = os.environ.get("MINIFORGE_NAME", "Miniforge3") %}
 {% set version = os.environ.get("MINIFORGE_VERSION", "23.10.0-0") %}
-{% set conda_libmamba_solver_version = "23.11.0"%}
+{% set conda_libmamba_solver_version = "23.11.1"%}
 {% set mamba_version = "1.5.3"%}
 
 name: {{ name }}

--- a/Miniforge3/construct.yaml
+++ b/Miniforge3/construct.yaml
@@ -1,6 +1,6 @@
 {% set name = os.environ.get("MINIFORGE_NAME", "Miniforge3") %}
 {% set version = os.environ.get("MINIFORGE_VERSION", "23.7.4-0") %}
-{% set conda_libmamba_solver_version = "23.7.0"%}
+{% set conda_libmamba_solver_version = "23.9.1"%}
 {% set mamba_version = "1.5.1"%}
 
 name: {{ name }}

--- a/Miniforge3/construct.yaml
+++ b/Miniforge3/construct.yaml
@@ -1,6 +1,6 @@
 {% set name = os.environ.get("MINIFORGE_NAME", "Miniforge3") %}
 {% set version = os.environ.get("MINIFORGE_VERSION", "23.7.4-0") %}
-{% set conda_libmamba_solver_version = "23.7.4"%}
+{% set conda_libmamba_solver_version = "23.9.1"%}
 {% set mamba_version = "1.5.1"%}
 
 name: {{ name }}

--- a/Miniforge3/construct.yaml
+++ b/Miniforge3/construct.yaml
@@ -1,6 +1,6 @@
 {% set name = os.environ.get("MINIFORGE_NAME", "Miniforge3") %}
 {% set version = os.environ.get("MINIFORGE_VERSION", "23.7.4-0") %}
-{% set conda_libmamba_solver_version = "23.9.1"%}
+{% set conda_libmamba_solver_version = "23.7.0"%}
 {% set mamba_version = "1.5.1"%}
 
 name: {{ name }}

--- a/Miniforge3/construct.yaml
+++ b/Miniforge3/construct.yaml
@@ -1,6 +1,6 @@
 {% set name = os.environ.get("MINIFORGE_NAME", "Miniforge3") %}
-{% set version = os.environ.get("MINIFORGE_VERSION", "23.7.4-0") %}
-{% set conda_libmamba_solver_version = "23.10.0"%}
+{% set version = os.environ.get("MINIFORGE_VERSION", "23.10.0-0") %}
+{% set conda_libmamba_solver_version = "23.11.0"%}
 {% set mamba_version = "1.5.3"%}
 
 name: {{ name }}

--- a/Miniforge3/construct.yaml
+++ b/Miniforge3/construct.yaml
@@ -1,7 +1,7 @@
 {% set name = os.environ.get("MINIFORGE_NAME", "Miniforge3") %}
 {% set version = os.environ.get("MINIFORGE_VERSION", "23.7.4-0") %}
-{% set conda_libmamba_solver_version = "23.9.1"%}
-{% set mamba_version = "1.5.1"%}
+{% set conda_libmamba_solver_version = "23.10.0"%}
+{% set mamba_version = "1.5.3"%}
 
 name: {{ name }}
 version: {{ version }}

--- a/build_miniforge_osx.sh
+++ b/build_miniforge_osx.sh
@@ -1,32 +1,8 @@
 #!/bin/bash
 
-set -e
-set -x
+set -eux
 
-echo "Installing a fresh version of Miniforge3."
-# Keep variable names in sync with
-# https://github.com/conda-forge/docker-images/blob/main/scripts/run_commands
-miniforge_arch="$(uname -m)"
-miniforge_version="4.14.0-0"
-condapkg="https://github.com/conda-forge/miniforge/releases/download/${miniforge_version}/Mambaforge-${miniforge_version}-MacOSX-${miniforge_arch}.sh"
-if [ "$(uname -m)" = "x86_64" ]; then
-   conda_checksum="949f046b4404cc8e081807b048050e6642d8db5520c20d5158a7ef721fbf76c5"
-elif [ "$(uname -m)" = "arm64" ]; then
-   conda_checksum="35d05a65e19b8e5d596964936ddd6023ae66d664a25ba291a52fec18f06a73b6"
-else
-   exit 1
-fi
-curl -s -L "$condapkg" -o miniconda.sh
-openssl sha256 miniconda.sh | grep $conda_checksum
-
-bash miniconda.sh -b -p ~/conda
-
-echo "Configuring conda."
-# shellcheck disable=SC1090
-source ~/conda/bin/activate root
-
-export CONSTRUCT_ROOT="${PWD}"
-mkdir -p build
+eval "$(PS1="${PS1-}" conda shell.posix activate)"
 
 bash scripts/build.sh
 # shellcheck disable=SC2154


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
closes gh-496
closes gh-511
<!--
Please add any other relevant info below:
-->
Continuation of gh-496 using `setup-miniconda` for macOS and updating to `conda-libmamba-solver=23.11.1`.
