### PR TITLE
Add warnings to deprecate Mambaforge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,7 +197,7 @@ jobs:
         if: ${{ ! contains(matrix.OS_NAME, 'Linux') }}
       
       - name: Patch license for Mambaforge deprecation
-        if: matrix.MINIFORGE_NAME == 'Mambaforge'
+        if: matrix.MINIFORGE_NAME == 'Mambaforge' || matrix.MINIFORGE_NAME == 'Mambaforge-pypy3'
         run: |
           echo "!!!!!! Mambaforge is now deprecated !!!!!" > MAMBAFORGE_LICENSE.txt
           echo "Future Miniforge releases will NOT build Mambaforge installers." >> MAMBAFORGE_LICENSE.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,6 +202,7 @@ jobs:
           echo "!!!!!! Mambaforge is now deprecated !!!!!" > Miniforge3/MAMBAFORGE_LICENSE.txt
           echo "Future Miniforge releases will NOT build Mambaforge installers." >> Miniforge3/MAMBAFORGE_LICENSE.txt
           echo "We advise you switch to Miniforge at your earliest convenience." >> Miniforge3/MAMBAFORGE_LICENSE.txt
+          echo "More details at https://conda-forge.org/news/2024/07/29/sunsetting-mambaforge/." >> Miniforge3/MAMBAFORGE_LICENSE.txt
           echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" >> Miniforge3/MAMBAFORGE_LICENSE.txt
           cat LICENSE >> Miniforge3/MAMBAFORGE_LICENSE.txt
           echo "MINIFORGE_LICENSE_OVERRIDE=MAMBAFORGE_LICENSE.txt" >> $GITHUB_ENV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,12 +199,12 @@ jobs:
       - name: Patch license for Mambaforge deprecation
         if: matrix.MINIFORGE_NAME == 'Mambaforge' || matrix.MINIFORGE_NAME == 'Mambaforge-pypy3'
         run: |
-          echo "!!!!!! Mambaforge is now deprecated !!!!!" > MAMBAFORGE_LICENSE.txt
-          echo "Future Miniforge releases will NOT build Mambaforge installers." >> MAMBAFORGE_LICENSE.txt
-          echo "We advise you switch to Miniforge at your earliest convenience." >> MAMBAFORGE_LICENSE.txt
-          echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" >> MAMBAFORGE_LICENSE.txt
-          cat LICENSE >> MAMBAFORGE_LICENSE.txt
-          echo "MINIFORGE_LICENSE_OVERRIDE=../MAMBAFORGE_LICENSE.txt" >> $GITHUB_ENV
+          echo "!!!!!! Mambaforge is now deprecated !!!!!" > Miniforge3/MAMBAFORGE_LICENSE.txt
+          echo "Future Miniforge releases will NOT build Mambaforge installers." >> Miniforge3/MAMBAFORGE_LICENSE.txt
+          echo "We advise you switch to Miniforge at your earliest convenience." >> Miniforge3/MAMBAFORGE_LICENSE.txt
+          echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" >> Miniforge3/MAMBAFORGE_LICENSE.txt
+          cat LICENSE >> Miniforge3/MAMBAFORGE_LICENSE.txt
+          echo "MINIFORGE_LICENSE_OVERRIDE=MAMBAFORGE_LICENSE.txt" >> $GITHUB_ENV
 
       - name: Build and test miniforge
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,6 +195,16 @@ jobs:
           miniforge-variant: Mambaforge
           use-mamba: true
         if: ${{ ! contains(matrix.OS_NAME, 'Linux') }}
+      
+      - name: Patch license for Mambaforge deprecation
+        if: matrix.MINIFORGE_NAME == 'Mambaforge'
+        run:
+          echo "!!!!!! Mambaforge is now deprecated !!!!!" > MAMBAFORGE_LICENSE.txt
+          echo "Future Miniforge releases will NOT build Mambaforge installers." >> MAMBAFORGE_LICENSE.txt
+          echo "We advise you switch to Miniforge at your earliest convenience." >> MAMBAFORGE_LICENSE.txt
+          echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" >> MAMBAFORGE_LICENSE.txt
+          cat LICENSE >> MAMBAFORGE_LICENSE.txt
+          echo "MINIFORGE_LICENSE_OVERRIDE=../MAMBAFORGE_LICENSE.txt" >> $GITHUB_ENV
 
       - name: Build and test miniforge
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,7 +198,7 @@ jobs:
       
       - name: Patch license for Mambaforge deprecation
         if: matrix.MINIFORGE_NAME == 'Mambaforge'
-        run:
+        run: |
           echo "!!!!!! Mambaforge is now deprecated !!!!!" > MAMBAFORGE_LICENSE.txt
           echo "Future Miniforge releases will NOT build Mambaforge installers." >> MAMBAFORGE_LICENSE.txt
           echo "We advise you switch to Miniforge at your earliest convenience." >> MAMBAFORGE_LICENSE.txt

--- a/Miniforge3/construct.yaml
+++ b/Miniforge3/construct.yaml
@@ -17,7 +17,7 @@ write_condarc: True
 # keep pkgs for space-saving implications for hardlinks when create new environments
 # and keep the same with Miniconda
 keep_pkgs: True
-license_file: ../LICENSE
+license_file: {{ os.environ.get("MINIFORGE_LICENSE_OVERRIDE", "../LICENSE") }}
 
 # During the interactive installation, these variables are checked.
 # During batch installation, conda is never initialized
@@ -48,3 +48,6 @@ specs:
 
   - pip
   - miniforge_console_shortcut 1.*  # [win]
+
+pre_install: mambaforge_deprecation.sh  # [unix]
+pre_install: mambaforge_deprecation.bat  # [win]

--- a/Miniforge3/mambaforge_deprecation.bat
+++ b/Miniforge3/mambaforge_deprecation.bat
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if "$GITHUB_ACTIONS"=="1" (
+    echo ::warning title=Mambaforge is now deprecated!::Future Miniforge releases will NOT build Mambaforge installers. We advise you switch to Miniforge at your earliest convenience.
+)
+else (
+    msg "%sessionname%" Mambaforge is now deprecated! Future Miniforge releases will NOT build Mambaforge installers. We advise you switch to Miniforge at your earliest convenience.
+    timeout /t 30 /nobreak
+)

--- a/Miniforge3/mambaforge_deprecation.bat
+++ b/Miniforge3/mambaforge_deprecation.bat
@@ -1,9 +1,8 @@
-#!/bin/bash
-
-if "$GITHUB_ACTIONS"=="1" (
+if "%GITHUB_ACTIONS%"=="true" (
     echo ::warning title=Mambaforge is now deprecated!::Future Miniforge releases will NOT build Mambaforge installers. We advise you switch to Miniforge at your earliest convenience.
 )
 else (
     msg "%sessionname%" Mambaforge is now deprecated! Future Miniforge releases will NOT build Mambaforge installers. We advise you switch to Miniforge at your earliest convenience.
-    timeout /t 30 /nobreak
 )
+echo Sleeping for 30s...
+powershell -nop -c "& {sleep 30}"

--- a/Miniforge3/mambaforge_deprecation.bat
+++ b/Miniforge3/mambaforge_deprecation.bat
@@ -1,8 +1,25 @@
 if "%GITHUB_ACTIONS%"=="true" (
-    echo ::warning title=Mambaforge is now deprecated!::Future Miniforge releases will NOT build Mambaforge installers. We advise you switch to Miniforge at your earliest convenience.
+    echo ::warning title=Mambaforge is now deprecated!::Future Miniforge releases will NOT build Mambaforge installers. We advise you switch to Miniforge at your earliest convenience. More details at https://conda-forge.org/news/2024/07/29/sunsetting-mambaforge/.
 )
 else (
-    msg "%sessionname%" Mambaforge is now deprecated! Future Miniforge releases will NOT build Mambaforge installers. We advise you switch to Miniforge at your earliest convenience.
+    msg "%sessionname%" Mambaforge is now deprecated! Future Miniforge releases will NOT build Mambaforge installers. We advise you switch to Miniforge at your earliest convenience. More details at https://conda-forge.org/news/2024/07/29/sunsetting-mambaforge/.
 )
+
+for /f "delims=" %%# in ('powershell get-date -format "{yyyy-MM-dd}"') do @set _date=%%#
+if "%_date%"=="2024-10-01" exit 1
+if "%_date%"=="2024-10-15" exit 1
+if "%_date%"=="2024-11-01" exit 1
+if "%_date%"=="2024-11-10" exit 1
+if "%_date%"=="2024-11-20" exit 1
+if "%_date%"=="2024-11-30" exit 1
+if "%_date%"=="2024-12-05" exit 1
+if "%_date%"=="2024-12-10" exit 1
+if "%_date%"=="2024-12-15" exit 1
+if "%_date%"=="2024-12-20" exit 1
+if "%_date%"=="2024-12-25" exit 1
+if "%_date%"=="2024-12-30" exit 1
+if "%_date%"=="2024-12-31" exit 1
+if "%_date:~0,4%"=="2025"  exit 1
+
 echo Sleeping for 30s...
 powershell -nop -c "& {sleep 30}"

--- a/Miniforge3/mambaforge_deprecation.sh
+++ b/Miniforge3/mambaforge_deprecation.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if [[ "$GITHUB_ACTIONS" == "1"]];
+    echo "::warning title=Mambaforge is now deprecated!::Future Miniforge releases will NOT build Mambaforge installers. We advise you switch to Miniforge at your earliest convenience."
+else
+    echo "!!!!!! Mambaforge is now deprecated !!!!!"
+    echo "Future Miniforge releases will NOT build Mambaforge installers."
+    echo "We advise you switch to Miniforge at your earliest convenience."
+    echo "Sleeping for 30s..."
+    sleep 30
+fi

--- a/Miniforge3/mambaforge_deprecation.sh
+++ b/Miniforge3/mambaforge_deprecation.sh
@@ -1,11 +1,21 @@
 #!/bin/bash
 
 if [[ "$GITHUB_ACTIONS" == "true" ]]; then
-    echo "::warning title=Mambaforge is now deprecated!::Future Miniforge releases will NOT build Mambaforge installers. We advise you switch to Miniforge at your earliest convenience."
+    echo "::warning title=Mambaforge is now deprecated!::Future Miniforge releases will NOT build Mambaforge installers. We advise you switch to Miniforge at your earliest convenience. More details at https://conda-forge.org/news/2024/07/29/sunsetting-mambaforge/."
 else
     echo "!!!!!! Mambaforge is now deprecated !!!!!"
     echo "Future Miniforge releases will NOT build Mambaforge installers."
     echo "We advise you switch to Miniforge at your earliest convenience."
+    echo "More details at https://conda-forge.org/news/2024/07/29/sunsetting-mambaforge/."
 fi
-echo "Sleeping for 30s..."
-sleep 30
+
+case $(date +%F) in 
+    # Brownouts
+    2024-10-01|2024-10-15|2024-11-01|2024-11-10|2024-11-20|2024-11-30|2024-12-05|2024-12-10|2024-12-15|2024-12-20|2024-12-25|2024-12-30|2024-12-31|2025-*)
+        exit 1
+    ;;
+    *)
+        echo "Sleeping for 30s..."
+        sleep 30
+    ;;
+esac

--- a/Miniforge3/mambaforge_deprecation.sh
+++ b/Miniforge3/mambaforge_deprecation.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [[ "$GITHUB_ACTIONS" == "1" ]];
+if [[ "$GITHUB_ACTIONS" == "1" ]]; then
     echo "::warning title=Mambaforge is now deprecated!::Future Miniforge releases will NOT build Mambaforge installers. We advise you switch to Miniforge at your earliest convenience."
 else
     echo "!!!!!! Mambaforge is now deprecated !!!!!"

--- a/Miniforge3/mambaforge_deprecation.sh
+++ b/Miniforge3/mambaforge_deprecation.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-if [[ "$GITHUB_ACTIONS" == "1" ]]; then
+if [[ "$GITHUB_ACTIONS" == "true" ]]; then
     echo "::warning title=Mambaforge is now deprecated!::Future Miniforge releases will NOT build Mambaforge installers. We advise you switch to Miniforge at your earliest convenience."
 else
     echo "!!!!!! Mambaforge is now deprecated !!!!!"
     echo "Future Miniforge releases will NOT build Mambaforge installers."
     echo "We advise you switch to Miniforge at your earliest convenience."
-    echo "Sleeping for 30s..."
-    sleep 30
 fi
+echo "Sleeping for 30s..."
+sleep 30

--- a/Miniforge3/mambaforge_deprecation.sh
+++ b/Miniforge3/mambaforge_deprecation.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [[ "$GITHUB_ACTIONS" == "1"]];
+if [[ "$GITHUB_ACTIONS" == "1" ]];
     echo "::warning title=Mambaforge is now deprecated!::Future Miniforge releases will NOT build Mambaforge installers. We advise you switch to Miniforge at your earliest convenience."
 else
     echo "!!!!!! Mambaforge is now deprecated !!!!!"

--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ Latest installers with PyPy 3.9 in the base environment:
 | OS X    | x86_64             | macOS >= 10.13   | [Miniforge-pypy3-MacOSX-x86_64](https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge-pypy3-MacOSX-x86_64.sh) |
 | Windows | x86_64             | Windows >= 7     | [Miniforge-pypy3-Windows-x86_64](https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge-pypy3-Windows-x86_64.exe) |
 
-<details><summary>Mambaforge (Discouraged as of September 2023)</summary>
+<details>
+
+<summary>🚨 Mambaforge (<b>Deprecated</b> as of July 2024) 🚨</summary>
 
 With the [release](https://github.com/conda-forge/miniforge/releases/tag/23.3.1-0) of
 `Miniforge3-23.3.1-0`, that incorporated the changes in
@@ -58,12 +60,8 @@ configuration of `Mambaforge` and `Miniforge3` are now **identical**. The
 only difference between the two is the name of the installer and, subsequently,
 the default installation directory.
 
-Given its wide usage, there are no plans to deprecate Mambaforge. If at some
-point we decide to deprecate Mambaforge, it will be appropriately announced and
-communicated with sufficient time in advance.
-
-As of September 2023, the new usage of Mambaforge is thus discouraged. Bug
-reports specific to Mambaforge will be closed as won't fix.
+We recommend switching to `Miniforge3` immediately. These installers will be 
+eventually removed.
 
 #### Mambaforge
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,13 @@ only difference between the two is the name of the installer and, subsequently,
 the default installation directory.
 
 We recommend switching to `Miniforge3` immediately. These installers will be 
-retired in January 2025.
+retired in January 2025. To assist in the migration to Miniforge3 for CI users, we've stopped
+the latest Mambaforge (24.5+) installer from proceeding with following schedule
+
+* Every two weeks in October
+* Every ten days in November
+* Every five days in December
+* Never in 2025
 
 #### Mambaforge
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ only difference between the two is the name of the installer and, subsequently,
 the default installation directory.
 
 We recommend switching to `Miniforge3` immediately. These installers will be 
-eventually removed.
+retired in January 2025.
 
 #### Mambaforge
 

--- a/build_miniforge.sh
+++ b/build_miniforge.sh
@@ -30,7 +30,7 @@ docker run --privileged --rm tonistiigi/binfmt --install all
 
 echo "============= Build the installer ============="
 docker run --rm -v "$(pwd):/construct" \
-  -e CONSTRUCT_ROOT -e MINIFORGE_VERSION -e MINIFORGE_NAME -e TARGET_PLATFORM \
+  -e CONSTRUCT_ROOT -e MINIFORGE_VERSION -e MINIFORGE_NAME -e TARGET_PLATFORM -e MINIFORGE_LICENSE_OVERRIDE \
   "${DOCKERIMAGE}" /construct/scripts/build.sh
 
 echo "============= Test the installer ============="


### PR DESCRIPTION
Comes from https://github.com/conda-forge/miniforge/issues/602.

I've added:

- A license override to show a message as early as possible, in all installers.
- Since that will possibly be ignored, a pre-install script will:
  - Echo a warning in Github Actions
  - Print a loud message in Unix
  - Throw a popup in Windows

To be decided, which deprecation periods we offer:
- Warnings: this is where we are now
- Brownouts: later but when
  - Include the brownouts in the installer itself; `exit 1` if the time and date is part of the preprogrammed brownout windows
  - Toggle the "Release is pre-release" button every now and then to switch between two identical Miniforge releases, but one has Mambaforge and the other doesn't
- Removal: you tell me

Ideally we print this information in these scary messages already.