### PR TITLE
Add additional information on what installers don't have this brownout

### DIFF
--- a/Miniforge3/mambaforge_deprecation.bat
+++ b/Miniforge3/mambaforge_deprecation.bat
@@ -1,25 +1,25 @@
 if "%GITHUB_ACTIONS%"=="true" (
-    echo ::warning title=Mambaforge is now deprecated!::Future Miniforge releases will NOT build Mambaforge installers. We advise you switch to Miniforge at your earliest convenience. More details at https://conda-forge.org/news/2024/07/29/sunsetting-mambaforge/.
+    echo ::warning title=Mambaforge is now deprecated!::Future Miniforge releases will NOT build Mambaforge installers. We advise you switch to Miniforge at your earliest convenience. More details at https://conda-forge.org/news/2024/07/29/sunsetting-mambaforge/. If you require mambaforge, you may pin your installer to one found from https://github.com/conda-forge/miniforge/releases/tag/24.5.0-1
 )
 else (
-    msg "%sessionname%" Mambaforge is now deprecated! Future Miniforge releases will NOT build Mambaforge installers. We advise you switch to Miniforge at your earliest convenience. More details at https://conda-forge.org/news/2024/07/29/sunsetting-mambaforge/.
+    msg "%sessionname%" Mambaforge is now deprecated! Future Miniforge releases will NOT build Mambaforge installers. We advise you switch to Miniforge at your earliest convenience. More details at https://conda-forge.org/news/2024/07/29/sunsetting-mambaforge/. If you require mambaforge, you may pin your installer to one found from https://github.com/conda-forge/miniforge/releases/tag/24.5.0-1
 )
 
-for /f "delims=" %%# in ('powershell get-date -format "{yyyy-MM-dd}"') do @set _date=%%#
-if "%_date%"=="2024-10-01" exit 1
-if "%_date%"=="2024-10-15" exit 1
-if "%_date%"=="2024-11-01" exit 1
-if "%_date%"=="2024-11-10" exit 1
-if "%_date%"=="2024-11-20" exit 1
-if "%_date%"=="2024-11-30" exit 1
-if "%_date%"=="2024-12-05" exit 1
-if "%_date%"=="2024-12-10" exit 1
-if "%_date%"=="2024-12-15" exit 1
-if "%_date%"=="2024-12-20" exit 1
-if "%_date%"=="2024-12-25" exit 1
-if "%_date%"=="2024-12-30" exit 1
-if "%_date%"=="2024-12-31" exit 1
-if "%_date:~0,4%"=="2025"  exit 1
-
-echo Sleeping for 30s...
-powershell -nop -c "& {sleep 30}"
+:REM for /f "delims=" %%# in ('powershell get-date -format "{yyyy-MM-dd}"') do @set _date=%%#
+:REM if "%_date%"=="2024-10-01" exit 1
+:REM if "%_date%"=="2024-10-15" exit 1
+:REM if "%_date%"=="2024-11-01" exit 1
+:REM if "%_date%"=="2024-11-10" exit 1
+:REM if "%_date%"=="2024-11-20" exit 1
+:REM if "%_date%"=="2024-11-30" exit 1
+:REM if "%_date%"=="2024-12-05" exit 1
+:REM if "%_date%"=="2024-12-10" exit 1
+:REM if "%_date%"=="2024-12-15" exit 1
+:REM if "%_date%"=="2024-12-20" exit 1
+:REM if "%_date%"=="2024-12-25" exit 1
+:REM if "%_date%"=="2024-12-30" exit 1
+:REM if "%_date%"=="2024-12-31" exit 1
+:REM if "%_date:~0,4%"=="2025"  exit 1
+:REM
+:REM echo Sleeping for 30s...
+:REM powershell -nop -c "& {sleep 30}"

--- a/Miniforge3/mambaforge_deprecation.sh
+++ b/Miniforge3/mambaforge_deprecation.sh
@@ -7,15 +7,21 @@ else
     echo "Future Miniforge releases will NOT build Mambaforge installers."
     echo "We advise you switch to Miniforge at your earliest convenience."
     echo "More details at https://conda-forge.org/news/2024/07/29/sunsetting-mambaforge/."
+    echo "If you are unable to switch to Miniforge, you may pin your installer version to one found in "
+    echo "https://github.com/conda-forge/miniforge/releases/tag/24.5.0-1"
+    echo "or if you lack the system requirements (Linux glibc >= 2.17, or macOS + x86-64bit >= 10.13)"
+    echo "you may pin your installer to one older version found in "
+    echo "https://github.com/conda-forge/miniforge/releases/tag/24.3.0-0"
+
 fi
 
-case $(date +%F) in 
-    # Brownouts
-    2024-10-01|2024-10-15|2024-11-01|2024-11-10|2024-11-20|2024-11-30|2024-12-05|2024-12-10|2024-12-15|2024-12-20|2024-12-25|2024-12-30|2024-12-31|2025-*)
-        exit 1
-    ;;
-    *)
-        echo "Sleeping for 30s..."
-        sleep 30
-    ;;
-esac
+# case $(date +%F) in
+#     # Brownouts
+#     2024-10-01|2024-10-15|2024-11-01|2024-11-10|2024-11-20|2024-11-30|2024-12-05|2024-12-10|2024-12-15|2024-12-20|2024-12-25|2024-12-30|2024-12-31|2025-*)
+#         exit 1
+#     ;;
+#     *)
+#         echo "Sleeping for 30s..."
+#         sleep 30
+#     ;;
+# esac

--- a/README.md
+++ b/README.md
@@ -53,6 +53,22 @@ Latest installers with PyPy 3.9 in the base environment:
 
 <summary>🚨 Mambaforge (<b>Deprecated</b> as of July 2024) 🚨</summary>
 
+Update for July 2024:
+
+As of July 2024, `Mambaforge` is deprecated. We suggest users switch to
+`Miniforge3` immediately. These installers will be retired from new releases
+after January 2025. To assist in the migration, we will be introducing rollowing
+brownouts to the latest Mambaforge installer. Installers up to version 24.5.0-1
+will not have any brownouts. 24.5.0-1 will include a warning message.
+Installers 2024.5.0-2 and later will have the following brownout schedule:
+
+* The installer will refuse to proceed every two weeks in October
+* The installer will refuse to proceed every ten days in November
+* The installer will refuse to proceed every five days in December
+* The installer will refuse to proceed in 2025+
+
+Previous information:
+
 With the [release](https://github.com/conda-forge/miniforge/releases/tag/23.3.1-0) of
 `Miniforge3-23.3.1-0`, that incorporated the changes in
 [#277](https://github.com/conda-forge/miniforge/pull/277), the packages and


### PR DESCRIPTION
I'm hoping to remove the brownout on the one next release.


Closes https://github.com/conda-forge/miniforge/issues/625
cc: @orbsmiv


Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
