### PR TITLE
Deprecate PyPy3 installers

### DIFF
--- a/Miniforge3/construct.yaml
+++ b/Miniforge3/construct.yaml
@@ -54,6 +54,9 @@ specs:
 {% if name.startswith("Mambaforge") %}
 pre_install: mambaforge_deprecation.sh  # [unix]
 pre_install: mambaforge_deprecation.bat  # [win]
+{% elif name.endswith("pypy3") %}
+pre_install: pypy_deprecation.sh  # [unix]
+pre_install: pypy_deprecation.bat  # [win]
 {% endif %}
 
 virtual_specs:

--- a/Miniforge3/construct.yaml
+++ b/Miniforge3/construct.yaml
@@ -29,25 +29,29 @@ initialize_by_default: False
 user_requested_specs:
 {% if name.endswith("pypy3") %}
   - python 3.9.* *_pypy
+  - conda >=24.7.1
+  - mamba >=1.5.9
 {% else %}
   - python 3.12.*
+  - conda >={{ version.split("-")[0] }}
+  - mamba >={{ mamba_version }}
 {% endif %}
   - pip
-  - conda >={{ version.split("-")[0] }}
   # Omit conda-libmamba-solver so that conda is free to remove it later
-  - mamba >={{ mamba_version }}
   - miniforge_console_shortcut 1.*  # [win]
 
 specs:
 {% if name.endswith("pypy3") %}
   - python 3.9.* *_pypy
+  - conda 24.7.1
+  - mamba 1.5.9
+  - conda-libmamba-solver 24.7.0
 {% else %}
   - python 3.12.*
-{% endif %}
   - conda {{ version.split("-")[0] }}
-  - conda-libmamba-solver {{ conda_libmamba_solver_version }}
   - mamba {{ mamba_version }}
-
+  - conda-libmamba-solver {{ conda_libmamba_solver_version }}
+{% endif %}
   - pip
   - miniforge_console_shortcut 1.*  # [win]
 

--- a/Miniforge3/pypy_deprecation.bat
+++ b/Miniforge3/pypy_deprecation.bat
@@ -1,6 +1,6 @@
 @ECHO OFF
 set "title=PyPy support is now deprecated!"
-set "message=PyPy support is now deprecated! Future Miniforge releases will NOT build installers with PyPy in their base envonrment. We advise you switch to Miniforge at your earliest convenience. More details at https://conda-forge.org/news/2024/08/14/sunsetting-pypy/ If you require Mambaforge, you may pin your installer to one found in https://github.com/conda-forge/miniforge/releases/tag/24.7.1-0"
+set "message=PyPy support is now deprecated! Future Miniforge releases will NOT build installers with PyPy in their base environment. We advise you switch to Miniforge at your earliest convenience. More details at https://conda-forge.org/news/2024/08/14/sunsetting-pypy/. If you require PyPy, you may pin your installer to one found in https://github.com/conda-forge/miniforge/releases/tag/24.7.1-0"
 if "%GITHUB_ACTIONS%"=="true" (
     echo ::warning title=%title%::%message%
 ) else (

--- a/Miniforge3/pypy_deprecation.bat
+++ b/Miniforge3/pypy_deprecation.bat
@@ -1,0 +1,27 @@
+@ECHO OFF
+set "title=PyPy support is now deprecated!"
+set "message=PyPy support is now deprecated! Future Miniforge releases will NOT build installers with PyPy in their base envonrment. We advise you switch to Miniforge at your earliest convenience. More details at https://conda-forge.org/news/2024/08/14/sunsetting-pypy/ If you require Mambaforge, you may pin your installer to one found in https://github.com/conda-forge/miniforge/releases/tag/24.7.1-0"
+if "%GITHUB_ACTIONS%"=="true" (
+    echo ::warning title=%title%::%message%
+) else (
+    powershell "(New-Object -ComObject Wscript.Shell).Popup('%message%',0,'%title%',0x30)" >NUL
+)
+
+for /f "delims=" %%# in ('powershell get-date -format "{yyyy-MM-dd}"') do @set _date=%%#
+if "%_date%"=="2024-10-01" exit 1
+if "%_date%"=="2024-10-15" exit 1
+if "%_date%"=="2024-11-01" exit 1
+if "%_date%"=="2024-11-10" exit 1
+if "%_date%"=="2024-11-20" exit 1
+if "%_date%"=="2024-11-30" exit 1
+if "%_date%"=="2024-12-05" exit 1
+if "%_date%"=="2024-12-10" exit 1
+if "%_date%"=="2024-12-15" exit 1
+if "%_date%"=="2024-12-20" exit 1
+if "%_date%"=="2024-12-25" exit 1
+if "%_date%"=="2024-12-30" exit 1
+if "%_date%"=="2024-12-31" exit 1
+if "%_date:~0,4%"=="2025"  exit 1
+
+echo Sleeping for 30s...
+powershell -c "& {sleep 30}"

--- a/Miniforge3/pypy_deprecation.sh
+++ b/Miniforge3/pypy_deprecation.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+if [[ "$GITHUB_ACTIONS" == "true" ]]; then
+    echo "::warning title=Mambaforge is now deprecated!::Future Miniforge releases will NOT build Mambaforge installers. We advise you switch to Miniforge at your earliest convenience. More details at https://conda-forge.org/news/2024/07/29/sunsetting-mambaforge/."
+else
+    echo "!!!!!! Conda-Forge PyPy is now deprecated !!!!!"
+    echo "Future Miniforge releases will NOT build with PyPy in the base environment installers."
+    echo "We advise you switch to Miniforge3 at your earliest convenience."
+    echo "More details at https://conda-forge.org/news/2024/08/14/sunsetting-pypy/"
+    echo "If you are unable to switch to Miniforge, you may pin your installer version to one found in "
+    echo "https://github.com/conda-forge/miniforge/releases/tag/24.3.0-1"
+    echo "or if you lack the system requirements (Linux glibc >= 2.17, or macOS + x86-64bit >= 10.13)"
+    echo "you may pin your installer to one older version found in "
+    echo "https://github.com/conda-forge/miniforge/releases/tag/24.3.0-0"
+    echo "This Miniforge installer will ceese to work in 2025."
+fi
+
+case $(date +%F) in
+    # Brownouts
+    2024-10-01|2024-10-15|2024-11-01|2024-11-10|2024-11-20|2024-11-30|2024-12-05|2024-12-10|2024-12-15|2024-12-20|2024-12-25|2024-12-30|2024-12-31|2025-*)
+        exit 1
+    ;;
+    *)
+        echo "Sleeping for 30s..."
+        sleep 30
+    ;;
+esac

--- a/README.md
+++ b/README.md
@@ -37,6 +37,22 @@ The versions listed as "System: 32-bit" are not compatible with the installers o
 
 `(***)` Apple silicon builds are experimental and haven't had testing like the other platforms.
 
+<details>
+
+<summary>🚨 PyPy support is deprecated (<b>Deprecated</b> as of August 2024) 🚨</summary>
+
+TL;DR: We are planning to remove PyPy from conda-forge feedstock recipes in a
+few weeks (and thus to stop building new releases of packages for PyPy), unless
+there is substantial enough interest to justify the continued maintenance
+effort.
+
+To help with this transition, the latest installers will:
+
+* The installer will refuse to proceed every two weeks in October
+* The installer will refuse to proceed every ten days in November
+* The installer will refuse to proceed every five days in December
+* The installer will refuse to proceed in 2025+
+
 #### Miniforge-pypy3
 
 Latest installers with PyPy 3.9 in the base environment:
@@ -48,6 +64,23 @@ Latest installers with PyPy 3.9 in the base environment:
 | Linux   | ppc64le (POWER8/9) | glibc >= 2.17    | [Miniforge-pypy3-Linux-ppc64le](https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge-pypy3-Linux-ppc64le.sh) |
 | macOS   | x86_64             | macOS >= 10.13   | [Miniforge-pypy3-MacOSX-x86_64](https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge-pypy3-MacOSX-x86_64.sh) |
 | Windows | x86_64             | Windows >= 7     | [Miniforge-pypy3-Windows-x86_64](https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge-pypy3-Windows-x86_64.exe) |
+
+However, the latest installers will cease to work and will stop being made available in 2025. You should therefore pin to 24.7.0 if you require PyPy3.
+
+https://github.com/conda-forge/miniforge/releases/download/24.7.1-0/Mambaforge-24.7.1-0-Linux-aarch64.sh
+| OS      | Architecture       | Minimum Version  | Miniforge Version | Download  |
+| --------|--------------------|------------------|-------------------|-----------|
+| Linux   | x86_64 (amd64)     | glibc >= 2.17    | 24.7.1-0 | [Miniforge-pypy3-24.7.1-0-Linux-x86_64](https://github.com/conda-forge/miniforge/releases/download/24.7.1-0/Miniforge-pypy3-24.7.1-0-Linux-x86_64.sh) |
+| Linux   | x86_64 (amd64)     | glibc >= 2.12    | 24.3.0-0 | [Miniforge-pypy3-24.3.0-0-Linux-x86_64](https://github.com/conda-forge/miniforge/releases/download/24.3.0-0/Miniforge-pypy3-24.3.0-0-Linux-x86_64.sh) |
+| Linux   | aarch64 (arm64)    | glibc >= 2.17    | 24.7.1-0 | [Miniforge-pypy3-24.7.1-0-Linux-aarch64](https://github.com/conda-forge/miniforge/releases/download/24.7.1-0/Miniforge-pypy3-24.7.1-0-Linux-aarch64.sh) |
+| Linux   | aarch64 (arm64)    | glibc >= 2.12    | 24.3.0-0 | [Miniforge-pypy3-24.3.0-0-Linux-aarch64](https://github.com/conda-forge/miniforge/releases/download/24.3.0-0/Miniforge-pypy3-24.3.0-0-Linux-aarch64.sh) |
+| Linux   | ppc64le (POWER8/9) | glibc >= 2.17    | 24.7.1-0 | [Miniforge-pypy3-24.7.1-0-Linux-ppc64le](https://github.com/conda-forge/miniforge/releases/download/24.7.1-0/Miniforge-pypy3-24.7.1-0-Linux-ppc64le.sh) |
+| Linux   | ppc64le (POWER8/9) | glibc >= 2.12    | 24.3.0-0 | [Miniforge-pypy3-24.3.0-0-Linux-ppc64le](https://github.com/conda-forge/miniforge/releases/download/24.3.0-0/Miniforge-pypy3-24.3.0-0-Linux-ppc64le.sh) |
+| macOS   | x86_64             | macOS >= 10.13   | 24.7.1-0 | [Miniforge-pypy3-24.7.1-0-MacOSX-x86_64](https://github.com/conda-forge/miniforge/releases/download/24.7.1-0/Miniforge-pypy3-24.7.1-0-MacOSX-x86_64.sh) |
+| macOS   | x86_64             | macOS >= 10.9    | 24.3.0-0 | [Miniforge-pypy3-24.3.0-0-MacOSX-x86_64](https://github.com/conda-forge/miniforge/releases/download/24.3.0-0/Miniforge-pypy3-24.3.0-0-MacOSX-x86_64.sh) |
+| Windows | x86_64             | Windows >= 7     | 24.7.1-0 | [Miniforge-pypy3-24.7.1-0-Windows-x86_64](https://github.com/conda-forge/miniforge/releases/download/24.7.1-0/Miniforge-pypy3-24.7.1-0-Windows-x86_64.exe) |
+
+</summary>
 
 <details>
 


### PR DESCRIPTION
Gonna leave this up here for 1 week for comments ahead of cutting a release:

Closes https://github.com/conda-forge/miniforge/issues/656



Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
