### PR TITLE
Use mamba 2 for the base installation of Miniforge

### DIFF
--- a/Miniforge3/construct.yaml
+++ b/Miniforge3/construct.yaml
@@ -1,5 +1,5 @@
-{% set version = os.environ.get("MINIFORGE_VERSION", "24.11.3-1") %}
-{% set conda_libmamba_solver_version = "25.1.0"%}
+{% set version = os.environ.get("MINIFORGE_VERSION", "25.1.1-0") %}
+{% set conda_libmamba_solver_version = "25.1.1"%}
 # When `mamba_version` is updated here, also update the value of:
 #   - `MICROMAMBA_VERSION` in `scripts/build.sh`
 #   - `MAMBA_VERSION` in `scripts/test.sh`

--- a/Miniforge3/construct.yaml
+++ b/Miniforge3/construct.yaml
@@ -37,7 +37,7 @@ user_requested_specs:
 specs:
   - python 3.12.*
   - conda {{ version.split("-")[0] }}
-  - mamba >={{ mamba_version }}
+  - mamba {{ mamba_version }}
   - conda-libmamba-solver {{ conda_libmamba_solver_version }}
   - pip
   - miniforge_console_shortcut 1.*  # [win]

--- a/Miniforge3/construct.yaml
+++ b/Miniforge3/construct.yaml
@@ -3,7 +3,7 @@
 # When `mamba_version` is updated here, also update the value of:
 #   - `MICROMAMBA_VERSION` in `scripts/build.sh`
 #   - `MAMBA_VERSION` in `scripts/test.sh`
-{% set mamba_version = "2.0.6.rc3" %}
+{% set mamba_version = "2.0.6" %}
 
 name: Miniforge3
 version: {{ version }}
@@ -29,7 +29,7 @@ initialize_by_default: False
 user_requested_specs:
   - python 3.12.*
   - conda >={{ version.split("-")[0] }}
-  - conda-forge/label/mamba_prerelease::mamba==2.0.6.rc3
+  - mamba >={{ mamba_version }}
   - pip
   # Omit conda-libmamba-solver so that conda is free to remove it later
   - miniforge_console_shortcut 1.*  # [win]
@@ -37,7 +37,7 @@ user_requested_specs:
 specs:
   - python 3.12.*
   - conda {{ version.split("-")[0] }}
-  - conda-forge/label/mamba_prerelease::mamba==2.0.6.rc3
+  - mamba >={{ mamba_version }}
   - conda-libmamba-solver {{ conda_libmamba_solver_version }}
   - pip
   - miniforge_console_shortcut 1.*  # [win]

--- a/Miniforge3/construct.yaml
+++ b/Miniforge3/construct.yaml
@@ -3,7 +3,7 @@
 # When `mamba_version` is updated here, also update the value of:
 #   - `MICROMAMBA_VERSION` in `scripts/build.sh`
 #   - `MAMBA_VERSION` in `scripts/test.sh`
-{% set mamba_version = "2.0.6.rc2" %}
+{% set mamba_version = "2.0.6.rc3" %}
 
 name: Miniforge3
 version: {{ version }}
@@ -29,7 +29,7 @@ initialize_by_default: False
 user_requested_specs:
   - python 3.12.*
   - conda >={{ version.split("-")[0] }}
-  - conda-forge/label/mamba_prerelease::mamba==2.0.6.rc2
+  - conda-forge/label/mamba_prerelease::mamba==2.0.6.rc3
   - pip
   # Omit conda-libmamba-solver so that conda is free to remove it later
   - miniforge_console_shortcut 1.*  # [win]
@@ -37,7 +37,7 @@ user_requested_specs:
 specs:
   - python 3.12.*
   - conda {{ version.split("-")[0] }}
-  - conda-forge/label/mamba_prerelease::mamba==2.0.6.rc2
+  - conda-forge/label/mamba_prerelease::mamba==2.0.6.rc3
   - conda-libmamba-solver {{ conda_libmamba_solver_version }}
   - pip
   - miniforge_console_shortcut 1.*  # [win]

--- a/Miniforge3/construct.yaml
+++ b/Miniforge3/construct.yaml
@@ -1,10 +1,8 @@
 {% set name = os.environ.get("MINIFORGE_NAME", "Miniforge3") %}
-{% set version = os.environ.get("MINIFORGE_VERSION", "24.11.2-1") %}
-{% set conda_libmamba_solver_version = "24.9.0"%}
+{% set version = os.environ.get("MINIFORGE_VERSION", "24.11.3-0") %}
+{% set conda_libmamba_solver_version = "24.11.1"%}
 # when mamba_version is updated here, also update MICROMAMBA_VERSION in scripts/build.sh
-# As of Dec 2024 -- mamba 2.0.5 isn't compatible with constructor
-# https://github.com/conda-forge/miniforge/issues/697
-{% set mamba_version = "1.5.12" %}
+{% set mamba_version = "2.0.5" %}
 
 name: {{ name }}
 version: {{ version }}

--- a/Miniforge3/construct.yaml
+++ b/Miniforge3/construct.yaml
@@ -1,4 +1,4 @@
-{% set version = os.environ.get("MINIFORGE_VERSION", "24.11.3-0") %}
+{% set version = os.environ.get("MINIFORGE_VERSION", "24.11.3-1") %}
 {% set conda_libmamba_solver_version = "24.11.1"%}
 # when mamba_version is updated here, also update MICROMAMBA_VERSION in scripts/build.sh
 {% set mamba_version = "2.0.5" %}

--- a/Miniforge3/construct.yaml
+++ b/Miniforge3/construct.yaml
@@ -3,7 +3,7 @@
 # When `mamba_version` is updated here, also update the value of:
 #   - `MICROMAMBA_VERSION` in `scripts/build.sh`
 #   - `MAMBA_VERSION` in `scripts/test.sh`
-{% set mamba_version = "2.0.6.rc1" %}
+{% set mamba_version = "2.0.6.rc2" %}
 
 name: Miniforge3
 version: {{ version }}
@@ -29,7 +29,7 @@ initialize_by_default: False
 user_requested_specs:
   - python 3.12.*
   - conda >={{ version.split("-")[0] }}
-  - conda-forge/label/mamba_prerelease::mamba==2.0.6.rc1
+  - conda-forge/label/mamba_prerelease::mamba==2.0.6.rc2
   - pip
   # Omit conda-libmamba-solver so that conda is free to remove it later
   - miniforge_console_shortcut 1.*  # [win]
@@ -37,7 +37,7 @@ user_requested_specs:
 specs:
   - python 3.12.*
   - conda {{ version.split("-")[0] }}
-  - conda-forge/label/mamba_prerelease::mamba==2.0.6.rc1
+  - conda-forge/label/mamba_prerelease::mamba==2.0.6.rc2
   - conda-libmamba-solver {{ conda_libmamba_solver_version }}
   - pip
   - miniforge_console_shortcut 1.*  # [win]

--- a/Miniforge3/construct.yaml
+++ b/Miniforge3/construct.yaml
@@ -1,6 +1,8 @@
 {% set version = os.environ.get("MINIFORGE_VERSION", "24.11.3-1") %}
 {% set conda_libmamba_solver_version = "24.11.1"%}
-# when mamba_version is updated here, also update MICROMAMBA_VERSION in scripts/build.sh
+# When `mamba_version` is updated here, also update the value of:
+#   - `MICROMAMBA_VERSION` in `scripts/build.sh`
+#   - `MAMBA_VERSION` in `scripts/test.sh`
 {% set mamba_version = "2.0.5" %}
 
 name: Miniforge3

--- a/Miniforge3/construct.yaml
+++ b/Miniforge3/construct.yaml
@@ -1,5 +1,5 @@
 {% set version = os.environ.get("MINIFORGE_VERSION", "24.11.3-1") %}
-{% set conda_libmamba_solver_version = "24.11.1"%}
+{% set conda_libmamba_solver_version = "25.1.0"%}
 # When `mamba_version` is updated here, also update the value of:
 #   - `MICROMAMBA_VERSION` in `scripts/build.sh`
 #   - `MAMBA_VERSION` in `scripts/test.sh`

--- a/Miniforge3/construct.yaml
+++ b/Miniforge3/construct.yaml
@@ -3,7 +3,7 @@
 # When `mamba_version` is updated here, also update the value of:
 #   - `MICROMAMBA_VERSION` in `scripts/build.sh`
 #   - `MAMBA_VERSION` in `scripts/test.sh`
-{% set mamba_version = "2.0.5" %}
+{% set mamba_version = "2.0.6.rc1" %}
 
 name: Miniforge3
 version: {{ version }}
@@ -29,7 +29,7 @@ initialize_by_default: False
 user_requested_specs:
   - python 3.12.*
   - conda >={{ version.split("-")[0] }}
-  - mamba >={{ mamba_version }}
+  - conda-forge/label/mamba_prerelease::mamba==2.0.6.rc1
   - pip
   # Omit conda-libmamba-solver so that conda is free to remove it later
   - miniforge_console_shortcut 1.*  # [win]
@@ -37,7 +37,7 @@ user_requested_specs:
 specs:
   - python 3.12.*
   - conda {{ version.split("-")[0] }}
-  - mamba {{ mamba_version }}
+  - conda-forge/label/mamba_prerelease::mamba==2.0.6.rc1
   - conda-libmamba-solver {{ conda_libmamba_solver_version }}
   - pip
   - miniforge_console_shortcut 1.*  # [win]

--- a/build_miniforge.sh
+++ b/build_miniforge.sh
@@ -37,6 +37,5 @@ for TEST_IMAGE_NAME in ${TEST_IMAGE_NAMES}; do
   echo "============= Test installer on ${TEST_IMAGE_NAME} ============="
   docker run --rm \
     -v "$(pwd):${CONSTRUCT_ROOT}" -e CONSTRUCT_ROOT \
-    -v /etc/ssl/certs:/etc/ssl/certs:ro \
     --platform "linux/${DOCKER_ARCH}" "${DOCKER_ARCH/\//}/${TEST_IMAGE_NAME}" /construct/scripts/test.sh
 done

--- a/build_miniforge.sh
+++ b/build_miniforge.sh
@@ -37,5 +37,5 @@ for TEST_IMAGE_NAME in ${TEST_IMAGE_NAMES}; do
   echo "============= Test installer on ${TEST_IMAGE_NAME} ============="
   docker run --rm \
     -v "$(pwd):${CONSTRUCT_ROOT}" -e CONSTRUCT_ROOT \
-    --platform "linux/${DOCKER_ARCH}" "${DOCKER_ARCH/\//}/${TEST_IMAGE_NAME}" /construct/scripts/test.sh
+     --platform "linux/${DOCKER_ARCH}" "${DOCKER_ARCH/\//}/${TEST_IMAGE_NAME}" /construct/scripts/test.sh
 done

--- a/build_miniforge.sh
+++ b/build_miniforge.sh
@@ -37,5 +37,6 @@ for TEST_IMAGE_NAME in ${TEST_IMAGE_NAMES}; do
   echo "============= Test installer on ${TEST_IMAGE_NAME} ============="
   docker run --rm \
     -v "$(pwd):${CONSTRUCT_ROOT}" -e CONSTRUCT_ROOT \
-     --platform "linux/${DOCKER_ARCH}" "${DOCKER_ARCH/\//}/${TEST_IMAGE_NAME}" /construct/scripts/test.sh
+    -v /etc/ssl/certs:/etc/ssl/certs:ro \
+    --platform "linux/${DOCKER_ARCH}" "${DOCKER_ARCH/\//}/${TEST_IMAGE_NAME}" /construct/scripts/test.sh
 done

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -38,7 +38,7 @@ cp LICENSE "${TEMP_DIR}/"
 ls -al "${TEMP_DIR}"
 
 if [[ "${TARGET_PLATFORM}" != win-* ]]; then
-    MICROMAMBA_VERSION=2.0.5
+    MICROMAMBA_VERSION=2.0.6.rc1
     MICROMAMBA_BUILD=0
     mkdir "${TEMP_DIR}/micromamba"
     pushd "${TEMP_DIR}/micromamba"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -38,7 +38,7 @@ cp LICENSE "${TEMP_DIR}/"
 ls -al "${TEMP_DIR}"
 
 if [[ "${TARGET_PLATFORM}" != win-* ]]; then
-    MICROMAMBA_VERSION=2.0.6.rc3
+    MICROMAMBA_VERSION=2.0.6
     MICROMAMBA_BUILD=0
     mkdir "${TEMP_DIR}/micromamba"
     pushd "${TEMP_DIR}/micromamba"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -14,7 +14,7 @@ echo "***** Install constructor *****"
 mamba install --yes \
     --channel conda-forge --override-channels \
     jinja2 curl libarchive \
-    "constructor>=3.9.3"
+    "constructor>=3.11.1"
 
 if [[ "$(uname)" == "Darwin" ]]; then
     mamba install --yes \
@@ -38,7 +38,7 @@ cp LICENSE "${TEMP_DIR}/"
 ls -al "${TEMP_DIR}"
 
 if [[ "${TARGET_PLATFORM}" != win-* ]]; then
-    MICROMAMBA_VERSION=1.5.11
+    MICROMAMBA_VERSION=2.0.5
     MICROMAMBA_BUILD=0
     mkdir "${TEMP_DIR}/micromamba"
     pushd "${TEMP_DIR}/micromamba"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -38,7 +38,7 @@ cp LICENSE "${TEMP_DIR}/"
 ls -al "${TEMP_DIR}"
 
 if [[ "${TARGET_PLATFORM}" != win-* ]]; then
-    MICROMAMBA_VERSION=2.0.6.rc1
+    MICROMAMBA_VERSION=2.0.6.rc2
     MICROMAMBA_BUILD=0
     mkdir "${TEMP_DIR}/micromamba"
     pushd "${TEMP_DIR}/micromamba"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -38,7 +38,7 @@ cp LICENSE "${TEMP_DIR}/"
 ls -al "${TEMP_DIR}"
 
 if [[ "${TARGET_PLATFORM}" != win-* ]]; then
-    MICROMAMBA_VERSION=2.0.6.rc2
+    MICROMAMBA_VERSION=2.0.6.rc3
     MICROMAMBA_BUILD=0
     mkdir "${TEMP_DIR}/micromamba"
     pushd "${TEMP_DIR}/micromamba"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -5,7 +5,7 @@ set -ex
 echo "***** Start: Testing Miniforge installer *****"
 
 export CONDA_PATH="${HOME}/miniforge"
-export MAMBA_VERSION="${MAMBA_VERSION:-2.0.6.rc1}"
+export MAMBA_VERSION="${MAMBA_VERSION:-2.0.6.rc2}"
 
 CONSTRUCT_ROOT="${CONSTRUCT_ROOT:-${PWD}}"
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -5,7 +5,7 @@ set -ex
 echo "***** Start: Testing Miniforge installer *****"
 
 export CONDA_PATH="${HOME}/miniforge"
-export MAMBA_VERSION="${MAMBA_VERSION:-2.0.6.rc3}"
+export MAMBA_VERSION="${MAMBA_VERSION:-2.0.6}"
 
 CONSTRUCT_ROOT="${CONSTRUCT_ROOT:-${PWD}}"
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -5,7 +5,7 @@ set -ex
 echo "***** Start: Testing Miniforge installer *****"
 
 export CONDA_PATH="${HOME}/miniforge"
-export MAMBA_VERSION="${MAMBA_VERSION:-2.0.5}"
+export MAMBA_VERSION="${MAMBA_VERSION:-2.0.6.rc1}"
 
 CONSTRUCT_ROOT="${CONSTRUCT_ROOT:-${PWD}}"
 
@@ -73,8 +73,8 @@ EOF
   conda list
 fi
 
-echo "+ Mamba does not warn (check that there is no warning on stderr)"
-mamba --help 2> stderr.log
+echo "+ Mamba does not warn (check that there is no warning on stderr) and returns exit code 0"
+mamba --help 2> stderr.log || cat stderr.log
 test ! -s stderr.log
 rm -f stderr.log
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -72,6 +72,28 @@ EOF
   conda list
 fi
 
+echo "+ Mamba does not warn (check that there is no warning on stderr)"
+mamba --help 2> stderr.log
+test ! -s stderr.log
+rm -f stderr.log
+
+echo "+ mamba info"
+mamba info
+
+echo "+ mamba config sources"
+mamba config sources
+
+echo "+ mamba config list"
+mamba config list
+
+echo "+ Testing mamba 2.0.5 version"
+mamba info --json | python -c "import sys, json; info = json.loads(sys.stdin.read()); assert info['mamba version'] == '2.0.5', info"
+echo "  OK"
+
+echo "+ Testing mamba channels"
+mamba info --json | python -c "import sys, json; info = json.loads(sys.stdin.read()); assert any('conda-forge' in c for c in info['channels']), info"
+echo "  OK"
+
 echo "***** Python path *****"
 python -c "import sys; print(sys.executable)"
 python -c "import sys; assert 'miniforge' in sys.executable"
@@ -84,3 +106,39 @@ python -c "import platform; print(platform.machine())"
 python -c "import platform; print(platform.release())"
 
 echo "***** Done: Testing installer *****"
+
+echo "***** Testing the usage of mamba main command *****"
+
+echo "***** Create a new environment *****"
+mamba create -n testenv numpy --yes
+
+echo "***** Activate the environment with mamba *****"
+mamba activate testenv
+
+echo "***** Check that numpy is installed with mamba list *****"
+mamba list | grep numpy
+
+echo "***** Deactivate the environment *****"
+mamba deactivate
+
+echo "***** Activate the environment with conda *****"
+conda activate testenv
+
+echo "***** Check that numpy is installed with python *****"
+python -c "import numpy; print(numpy.__version__)"
+
+echo "***** Remove numpy *****"
+mamba remove numpy --yes
+
+echo "***** Check that numpy is not installed with mamba list *****"
+mamba list | grep -v numpy
+
+
+echo "***** Deactivate the environment with conda *****"
+conda deactivate
+
+echo "***** Remove the environment *****"
+mamba env remove -n testenv --yes
+
+echo "***** Done: Testing mamba main command *****"
+

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -109,6 +109,9 @@ echo "***** Done: Testing installer *****"
 
 echo "***** Testing the usage of mamba main command *****"
 
+echo "***** Initialize the current session for mamba *****"
+eval "$(mamba shell hook --shell bash)"
+
 echo "***** Create a new environment *****"
 mamba create -n testenv numpy --yes
 
@@ -132,7 +135,6 @@ mamba remove numpy --yes
 
 echo "***** Check that numpy is not installed with mamba list *****"
 mamba list | grep -v numpy
-
 
 echo "***** Deactivate the environment with conda *****"
 conda deactivate

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -5,6 +5,7 @@ set -ex
 echo "***** Start: Testing Miniforge installer *****"
 
 export CONDA_PATH="${HOME}/miniforge"
+export MAMBA_VERSION="${MAMBA_VERSION:-2.0.5}"
 
 CONSTRUCT_ROOT="${CONSTRUCT_ROOT:-${PWD}}"
 
@@ -86,8 +87,8 @@ mamba config sources
 echo "+ mamba config list"
 mamba config list
 
-echo "+ Testing mamba 2.0.5 version"
-mamba info --json | python -c "import sys, json; info = json.loads(sys.stdin.read()); assert info['mamba version'] == '2.0.5', info"
+echo "+ Testing mamba version (i.e. ${MAMBA_VERSION})"
+mamba info --json | python -c "import sys, json; info = json.loads(sys.stdin.read()); assert info['mamba version'] == '${MAMBA_VERSION}', info"
 echo "  OK"
 
 echo "+ Testing mamba channels"
@@ -107,7 +108,7 @@ python -c "import platform; print(platform.release())"
 
 echo "***** Done: Testing installer *****"
 
-echo "***** Testing the usage of mamba main command *****"
+echo "***** Testing the usage of mamba main commands *****"
 
 echo "***** Initialize the current session for mamba *****"
 export MAMBA_ROOT_PREFIX="/root/miniforge"
@@ -145,5 +146,5 @@ conda deactivate
 echo "***** Remove the environment *****"
 mamba env remove -p $ENV_PREFIX --yes
 
-echo "***** Done: Testing mamba main command *****"
+echo "***** Done: Testing mamba main commands *****"
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -5,7 +5,7 @@ set -ex
 echo "***** Start: Testing Miniforge installer *****"
 
 export CONDA_PATH="${HOME}/miniforge"
-export MAMBA_VERSION="${MAMBA_VERSION:-2.0.6.rc2}"
+export MAMBA_VERSION="${MAMBA_VERSION:-2.0.6.rc3}"
 
 CONSTRUCT_ROOT="${CONSTRUCT_ROOT:-${PWD}}"
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -111,7 +111,6 @@ echo "***** Done: Testing installer *****"
 echo "***** Testing the usage of mamba main commands *****"
 
 echo "***** Initialize the current session for mamba *****"
-export MAMBA_ROOT_PREFIX="/root/miniforge"
 eval "$(mamba shell hook --shell bash)"
 
 echo "***** Create a new environment *****"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -110,13 +110,16 @@ echo "***** Done: Testing installer *****"
 echo "***** Testing the usage of mamba main command *****"
 
 echo "***** Initialize the current session for mamba *****"
+export MAMBA_ROOT_PREFIX="/root/miniforge"
 eval "$(mamba shell hook --shell bash)"
 
 echo "***** Create a new environment *****"
-mamba create -n testenv numpy --yes
+ENV_PREFIX="/tmp/testenv"
+
+mamba create -p $ENV_PREFIX numpy --yes -vvv
 
 echo "***** Activate the environment with mamba *****"
-mamba activate testenv
+mamba activate $ENV_PREFIX
 
 echo "***** Check that numpy is installed with mamba list *****"
 mamba list | grep numpy
@@ -125,7 +128,7 @@ echo "***** Deactivate the environment *****"
 mamba deactivate
 
 echo "***** Activate the environment with conda *****"
-conda activate testenv
+conda activate $ENV_PREFIX
 
 echo "***** Check that numpy is installed with python *****"
 python -c "import numpy; print(numpy.__version__)"
@@ -140,7 +143,7 @@ echo "***** Deactivate the environment with conda *****"
 conda deactivate
 
 echo "***** Remove the environment *****"
-mamba env remove -n testenv --yes
+mamba env remove -p $ENV_PREFIX --yes
 
 echo "***** Done: Testing mamba main command *****"
 


### PR DESCRIPTION
Follow-up of https://github.com/conda-forge/miniforge/pull/694 after the merge of https://github.com/conda/constructor/pull/914.

I am looking for ways to test this. For now, [the `Miniforge` example in `conda/constructor`](https://github.com/conda/constructor/tree/main/examples/miniforge) is the only one element which allows testing it locally.

@jaimergp, @hmaarrfk: do you have any recommendations for better testing this? :pray: