### PR TITLE
Use mamba 2 for the base installation of Miniforge (continued)

### DIFF
--- a/Miniforge3/construct.yaml
+++ b/Miniforge3/construct.yaml
@@ -1,9 +1,9 @@
-{% set version = os.environ.get("MINIFORGE_VERSION", "24.11.3-1") %}
-{% set conda_libmamba_solver_version = "24.9.0"%}
+{% set version = os.environ.get("MINIFORGE_VERSION", "25.1.1-1") %}
+{% set conda_libmamba_solver_version = "25.1.1" %}
 # This file is parsed by the scripts to define
 #   - `MICROMAMBA_VERSION` in `scripts/build.sh`
 #   - `MAMBA_VERSION` in `scripts/test.sh`
-{% set mamba_version = "1.5.12" %}
+{% set mamba_version = "2.0.7.rc0" %}
 
 name: Miniforge3
 version: {{ version }}
@@ -29,7 +29,7 @@ initialize_by_default: False
 user_requested_specs:
   - python 3.12.*
   - conda >={{ version.split("-")[0] }}
-  - mamba >={{ mamba_version }}
+  - conda-forge/label/mamba_prerelease::mamba==2.0.7.rc0
   - pip
   # Omit conda-libmamba-solver so that conda is free to remove it later
   - miniforge_console_shortcut 1.*  # [win]
@@ -37,7 +37,7 @@ user_requested_specs:
 specs:
   - python 3.12.*
   - conda {{ version.split("-")[0] }}
-  - mamba {{ mamba_version }}
+  - conda-forge/label/mamba_prerelease::mamba==2.0.7.rc0
   - conda-libmamba-solver {{ conda_libmamba_solver_version }}
   - pip
   - miniforge_console_shortcut 1.*  # [win]

--- a/Miniforge3/construct.yaml
+++ b/Miniforge3/construct.yaml
@@ -1,6 +1,6 @@
 {% set version = os.environ.get("MINIFORGE_VERSION", "25.1.1-1") %}
 {% set conda_libmamba_solver_version = "25.1.1" %}
-# This file is parsed by the scripts to define
+# When `mamba_version` is updated, also update:
 #   - `MICROMAMBA_VERSION` in `scripts/build.sh`
 #   - `MAMBA_VERSION` in `scripts/test.sh`
 {% set mamba_version = "2.0.7.rc0" %}

--- a/Miniforge3/construct.yaml
+++ b/Miniforge3/construct.yaml
@@ -3,7 +3,7 @@
 # This file is parsed by the scripts to define
 #   - `MICROMAMBA_VERSION` in `scripts/build.sh`
 #   - `MAMBA_VERSION` in `scripts/test.sh`
-{% set mamba_version = "2.0.7.rc1" %}
+{% set mamba_version = "2.0.7" %}
 
 name: Miniforge3
 version: {{ version }}
@@ -29,7 +29,7 @@ initialize_by_default: False
 user_requested_specs:
   - python 3.12.*
   - conda >={{ version.split("-")[0] }}
-  - conda-forge/label/mamba_prerelease::mamba=={{ mamba_version }}
+  - mamba >={{ mamba_version }}
   - pip
   # Omit conda-libmamba-solver so that conda is free to remove it later
   - miniforge_console_shortcut 1.*  # [win]
@@ -37,7 +37,7 @@ user_requested_specs:
 specs:
   - python 3.12.*
   - conda {{ version.split("-")[0] }}
-  - conda-forge/label/mamba_prerelease::mamba=={{ mamba_version }}
+  - mamba {{ mamba_version }}
   - conda-libmamba-solver {{ conda_libmamba_solver_version }}
   - pip
   - miniforge_console_shortcut 1.*  # [win]

--- a/Miniforge3/construct.yaml
+++ b/Miniforge3/construct.yaml
@@ -3,7 +3,7 @@
 # When `mamba_version` is updated, also update:
 #   - `MICROMAMBA_VERSION` in `scripts/build.sh`
 #   - `MAMBA_VERSION` in `scripts/test.sh`
-{% set mamba_version = "2.0.7.rc0" %}
+{% set mamba_version = "2.0.7.rc1" %}
 
 name: Miniforge3
 version: {{ version }}
@@ -29,7 +29,7 @@ initialize_by_default: False
 user_requested_specs:
   - python 3.12.*
   - conda >={{ version.split("-")[0] }}
-  - conda-forge/label/mamba_prerelease::mamba==2.0.7.rc0
+  - conda-forge/label/mamba_prerelease::mamba==2.0.7.rc1
   - pip
   # Omit conda-libmamba-solver so that conda is free to remove it later
   - miniforge_console_shortcut 1.*  # [win]
@@ -37,7 +37,7 @@ user_requested_specs:
 specs:
   - python 3.12.*
   - conda {{ version.split("-")[0] }}
-  - conda-forge/label/mamba_prerelease::mamba==2.0.7.rc0
+  - conda-forge/label/mamba_prerelease::mamba==2.0.7.rc1
   - conda-libmamba-solver {{ conda_libmamba_solver_version }}
   - pip
   - miniforge_console_shortcut 1.*  # [win]

--- a/Miniforge3/construct.yaml
+++ b/Miniforge3/construct.yaml
@@ -1,6 +1,6 @@
 {% set version = os.environ.get("MINIFORGE_VERSION", "25.1.1-1") %}
 {% set conda_libmamba_solver_version = "25.1.1" %}
-# When `mamba_version` is updated, also update:
+# This file is parsed by the scripts to define
 #   - `MICROMAMBA_VERSION` in `scripts/build.sh`
 #   - `MAMBA_VERSION` in `scripts/test.sh`
 {% set mamba_version = "2.0.7.rc1" %}
@@ -29,7 +29,7 @@ initialize_by_default: False
 user_requested_specs:
   - python 3.12.*
   - conda >={{ version.split("-")[0] }}
-  - conda-forge/label/mamba_prerelease::mamba==2.0.7.rc1
+  - conda-forge/label/mamba_prerelease::mamba=={{ mamba_version }}
   - pip
   # Omit conda-libmamba-solver so that conda is free to remove it later
   - miniforge_console_shortcut 1.*  # [win]
@@ -37,7 +37,7 @@ user_requested_specs:
 specs:
   - python 3.12.*
   - conda {{ version.split("-")[0] }}
-  - conda-forge/label/mamba_prerelease::mamba==2.0.7.rc1
+  - conda-forge/label/mamba_prerelease::mamba=={{ mamba_version }}
   - conda-libmamba-solver {{ conda_libmamba_solver_version }}
   - pip
   - miniforge_console_shortcut 1.*  # [win]

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -39,7 +39,7 @@ ls -al "${TEMP_DIR}"
 
 if [[ "${TARGET_PLATFORM}" != win-* ]]; then
     # Assumes specific structure in construct.yaml
-    MICROMAMBA_VERSION=$(grep "set mamba_version" Miniforge3/construct.yaml | cut -d '=' -f 2 | cut -d '"' -f 2)
+    MICROMAMBA_VERSION="2.0.7.rc0"
     MICROMAMBA_BUILD=0
     mkdir "${TEMP_DIR}/micromamba"
     pushd "${TEMP_DIR}/micromamba"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -39,7 +39,7 @@ ls -al "${TEMP_DIR}"
 
 if [[ "${TARGET_PLATFORM}" != win-* ]]; then
     # Assumes specific structure in construct.yaml
-    MICROMAMBA_VERSION="2.0.7.rc1"
+    MICROMAMBA_VERSION=$(grep "set mamba_version" Miniforge3/construct.yaml | cut -d '=' -f 2 | cut -d '"' -f 2)
     MICROMAMBA_BUILD=0
     mkdir "${TEMP_DIR}/micromamba"
     pushd "${TEMP_DIR}/micromamba"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -39,7 +39,7 @@ ls -al "${TEMP_DIR}"
 
 if [[ "${TARGET_PLATFORM}" != win-* ]]; then
     # Assumes specific structure in construct.yaml
-    MICROMAMBA_VERSION="2.0.7.rc0"
+    MICROMAMBA_VERSION="2.0.7.rc1"
     MICROMAMBA_BUILD=0
     mkdir "${TEMP_DIR}/micromamba"
     pushd "${TEMP_DIR}/micromamba"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -5,7 +5,7 @@ set -ex
 echo "***** Start: Testing Miniforge installer *****"
 
 export CONDA_PATH="${HOME}/miniforge"
-export MAMBA_VERSION="2.0.7.rc0"
+export MAMBA_VERSION="2.0.7.rc1"
 
 CONSTRUCT_ROOT="${CONSTRUCT_ROOT:-${PWD}}"
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -5,7 +5,8 @@ set -ex
 echo "***** Start: Testing Miniforge installer *****"
 
 export CONDA_PATH="${HOME}/miniforge"
-export MAMBA_VERSION="2.0.7.rc1"
+MAMBA_VERSION=$(grep "set mamba_version" Miniforge3/construct.yaml | cut -d '=' -f 2 | cut -d '"' -f 2)
+export MAMBA_VERSION
 
 CONSTRUCT_ROOT="${CONSTRUCT_ROOT:-${PWD}}"
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -5,8 +5,7 @@ set -ex
 echo "***** Start: Testing Miniforge installer *****"
 
 export CONDA_PATH="${HOME}/miniforge"
-MAMBA_VERSION=$(grep "set mamba_version" Miniforge3/construct.yaml | cut -d '=' -f 2 | cut -d '"' -f 2)
-export MAMBA_VERSION
+export MAMBA_VERSION=$(grep "set mamba_version" Miniforge3/construct.yaml | cut -d '=' -f 2 | cut -d '"' -f 2)
 
 CONSTRUCT_ROOT="${CONSTRUCT_ROOT:-${PWD}}"
 
@@ -74,6 +73,28 @@ EOF
   conda list
 fi
 
+echo "+ Mamba does not warn (check that there is no warning on stderr) and returns exit code 0"
+mamba --help 2> stderr.log || cat stderr.log
+test ! -s stderr.log
+rm -f stderr.log
+
+echo "+ mamba info"
+mamba info
+
+echo "+ mamba config sources"
+mamba config sources
+
+echo "+ mamba config list"
+mamba config list
+
+echo "+ Testing mamba version (i.e. ${MAMBA_VERSION})"
+mamba info --json | python -c "import sys, json; info = json.loads(sys.stdin.read()); assert info['mamba version'] == '${MAMBA_VERSION}', info"
+echo "  OK"
+
+echo "+ Testing mamba channels"
+mamba info --json | python -c "import sys, json; info = json.loads(sys.stdin.read()); assert any('conda-forge' in c for c in info['channels']), info"
+echo "  OK"
+
 echo "***** Python path *****"
 python -c "import sys; print(sys.executable)"
 python -c "import sys; assert 'miniforge' in sys.executable"
@@ -86,3 +107,43 @@ python -c "import platform; print(platform.machine())"
 python -c "import platform; print(platform.release())"
 
 echo "***** Done: Testing installer *****"
+
+echo "***** Testing the usage of mamba main commands *****"
+
+echo "***** Initialize the current session for mamba *****"
+eval "$(mamba shell hook --shell bash)"
+
+echo "***** Create a new environment *****"
+ENV_PREFIX="/tmp/testenv"
+
+mamba create -p $ENV_PREFIX numpy --yes -vvv
+
+echo "***** Activate the environment with mamba *****"
+mamba activate $ENV_PREFIX
+
+echo "***** Check that numpy is installed with mamba list *****"
+mamba list | grep numpy
+
+echo "***** Deactivate the environment *****"
+mamba deactivate
+
+echo "***** Activate the environment with conda *****"
+conda activate $ENV_PREFIX
+
+echo "***** Check that numpy is installed with python *****"
+python -c "import numpy; print(numpy.__version__)"
+
+echo "***** Remove numpy *****"
+mamba remove numpy --yes
+
+echo "***** Check that numpy is not installed with mamba list *****"
+mamba list | grep -v numpy
+
+echo "***** Deactivate the environment with conda *****"
+conda deactivate
+
+echo "***** Remove the environment *****"
+mamba env remove -p $ENV_PREFIX --yes
+
+echo "***** Done: Testing mamba main commands *****"
+

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -5,7 +5,7 @@ set -ex
 echo "***** Start: Testing Miniforge installer *****"
 
 export CONDA_PATH="${HOME}/miniforge"
-export MAMBA_VERSION=$(grep "set mamba_version" Miniforge3/construct.yaml | cut -d '=' -f 2 | cut -d '"' -f 2)
+export MAMBA_VERSION="2.0.7.rc0"
 
 CONSTRUCT_ROOT="${CONSTRUCT_ROOT:-${PWD}}"
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -4,13 +4,12 @@ set -ex
 
 echo "***** Start: Testing Miniforge installer *****"
 
+CONSTRUCT_ROOT="${CONSTRUCT_ROOT:-${PWD}}"
+cd "${CONSTRUCT_ROOT}"
+
 export CONDA_PATH="${HOME}/miniforge"
 MAMBA_VERSION=$(grep "set mamba_version" Miniforge3/construct.yaml | cut -d '=' -f 2 | cut -d '"' -f 2)
 export MAMBA_VERSION
-
-CONSTRUCT_ROOT="${CONSTRUCT_ROOT:-${PWD}}"
-
-cd "${CONSTRUCT_ROOT}"
 
 echo "***** Get the installer *****"
 ls build/


### PR DESCRIPTION
Follow-up of https://github.com/conda-forge/miniforge/pull/715.