### PR TITLE
Rebuild miniforge installation scripts

### DIFF
--- a/Miniforge3/construct.yaml
+++ b/Miniforge3/construct.yaml
@@ -1,4 +1,4 @@
-{% set version = os.environ.get("MINIFORGE_VERSION", "25.1.1-1") %}
+{% set version = os.environ.get("MINIFORGE_VERSION", "25.1.1-2") %}
 {% set conda_libmamba_solver_version = "25.1.1" %}
 # This file is parsed by the scripts to define
 #   - `MICROMAMBA_VERSION` in `scripts/build.sh`


### PR DESCRIPTION
`fmt 11.1` broke the ABI, breaking some builds of packages, including the one of spdlog and mamba 2.0.7.

In the meantime new builds of mamba have been issued to fix the problem.

See: https://github.com/mamba-org/mamba/issues/3862