### PR TITLE
Rebuild 25.1.1 2

### DIFF
--- a/Miniforge3/construct.yaml
+++ b/Miniforge3/construct.yaml
@@ -1,4 +1,4 @@
-{% set version = os.environ.get("MINIFORGE_VERSION", "25.1.1-1") %}
+{% set version = os.environ.get("MINIFORGE_VERSION", "25.1.1-2") %}
 {% set conda_libmamba_solver_version = "25.1.1" %}
 # This file is parsed by the scripts to define
 #   - `MICROMAMBA_VERSION` in `scripts/build.sh`

--- a/Miniforge3/construct.yaml
+++ b/Miniforge3/construct.yaml
@@ -1,9 +1,9 @@
-{% set version = os.environ.get("MINIFORGE_VERSION", "24.11.3-2") %}
-{% set conda_libmamba_solver_version = "24.9.0"%}
+{% set version = os.environ.get("MINIFORGE_VERSION", "25.1.1-1") %}
+{% set conda_libmamba_solver_version = "25.1.1" %}
 # This file is parsed by the scripts to define
 #   - `MICROMAMBA_VERSION` in `scripts/build.sh`
 #   - `MAMBA_VERSION` in `scripts/test.sh`
-{% set mamba_version = "1.5.12" %}
+{% set mamba_version = "2.0.7" %}
 
 name: Miniforge3
 version: {{ version }}

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -4,13 +4,12 @@ set -ex
 
 echo "***** Start: Testing Miniforge installer *****"
 
+CONSTRUCT_ROOT="${CONSTRUCT_ROOT:-${PWD}}"
+cd "${CONSTRUCT_ROOT}"
+
 export CONDA_PATH="${HOME}/miniforge"
 MAMBA_VERSION=$(grep "set mamba_version" Miniforge3/construct.yaml | cut -d '=' -f 2 | cut -d '"' -f 2)
 export MAMBA_VERSION
-
-CONSTRUCT_ROOT="${CONSTRUCT_ROOT:-${PWD}}"
-
-cd "${CONSTRUCT_ROOT}"
 
 echo "***** Get the installer *****"
 ls build/
@@ -74,6 +73,28 @@ EOF
   conda list
 fi
 
+echo "+ Mamba does not warn (check that there is no warning on stderr) and returns exit code 0"
+mamba --help 2> stderr.log || cat stderr.log
+test ! -s stderr.log
+rm -f stderr.log
+
+echo "+ mamba info"
+mamba info
+
+echo "+ mamba config sources"
+mamba config sources
+
+echo "+ mamba config list"
+mamba config list
+
+echo "+ Testing mamba version (i.e. ${MAMBA_VERSION})"
+mamba info --json | python -c "import sys, json; info = json.loads(sys.stdin.read()); assert info['mamba version'] == '${MAMBA_VERSION}', info"
+echo "  OK"
+
+echo "+ Testing mamba channels"
+mamba info --json | python -c "import sys, json; info = json.loads(sys.stdin.read()); assert any('conda-forge' in c for c in info['channels']), info"
+echo "  OK"
+
 echo "***** Python path *****"
 python -c "import sys; print(sys.executable)"
 python -c "import sys; assert 'miniforge' in sys.executable"
@@ -86,3 +107,43 @@ python -c "import platform; print(platform.machine())"
 python -c "import platform; print(platform.release())"
 
 echo "***** Done: Testing installer *****"
+
+echo "***** Testing the usage of mamba main commands *****"
+
+echo "***** Initialize the current session for mamba *****"
+eval "$(mamba shell hook --shell bash)"
+
+echo "***** Create a new environment *****"
+ENV_PREFIX="/tmp/testenv"
+
+mamba create -p $ENV_PREFIX numpy --yes -vvv
+
+echo "***** Activate the environment with mamba *****"
+mamba activate $ENV_PREFIX
+
+echo "***** Check that numpy is installed with mamba list *****"
+mamba list | grep numpy
+
+echo "***** Deactivate the environment *****"
+mamba deactivate
+
+echo "***** Activate the environment with conda *****"
+conda activate $ENV_PREFIX
+
+echo "***** Check that numpy is installed with python *****"
+python -c "import numpy; print(numpy.__version__)"
+
+echo "***** Remove numpy *****"
+mamba remove numpy --yes
+
+echo "***** Check that numpy is not installed with mamba list *****"
+mamba list | grep -v numpy
+
+echo "***** Deactivate the environment with conda *****"
+conda deactivate
+
+echo "***** Remove the environment *****"
+mamba env remove -p $ENV_PREFIX --yes
+
+echo "***** Done: Testing mamba main commands *****"
+


### PR DESCRIPTION
As promised here is the build number bump for conda 25.1.1
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
