### PR TITLE
[Do not merge] Testing decoupling pkgs/ and envs/ from the root prefix

### DIFF
--- a/Miniforge3/construct.yaml
+++ b/Miniforge3/construct.yaml
@@ -13,6 +13,7 @@ channels:
   # specifying the channel with the full URL adds two channels
   # when the end user adds the channel without the full URL
   # - https://conda.anaconda.org/conda-forge
+  - conda-canary/label/conda-conda-pr-14683
   - conda-forge
 
 write_condarc: True


### PR DESCRIPTION
This PR tests conda/conda#14683 to ensure that the new default locations of pkgs/ and envs/ works as intended. No need to merge this - logs of the `conda info` command will tell us all we need to know!