### PR TITLE
Update to mamba 2.1.0

### DIFF
--- a/Miniforge3/construct.yaml
+++ b/Miniforge3/construct.yaml
@@ -1,5 +1,5 @@
 {% set version = os.environ.get("MINIFORGE_VERSION", "25.4.0-0") %}
-{% set conda_libmamba_solver_version = "25.4.0" %}
+{% set conda_libmamba_solver_version = "25.3.0" %}
 # This file is parsed by the scripts to define
 #   - `MICROMAMBA_VERSION` in `scripts/build.sh`
 #   - `MAMBA_VERSION` in `scripts/test.sh`

--- a/Miniforge3/construct.yaml
+++ b/Miniforge3/construct.yaml
@@ -1,9 +1,9 @@
-{% set version = os.environ.get("MINIFORGE_VERSION", "25.3.0-1") %}
-{% set conda_libmamba_solver_version = "25.3.0" %}
+{% set version = os.environ.get("MINIFORGE_VERSION", "25.4.0-0") %}
+{% set conda_libmamba_solver_version = "25.4.0" %}
 # This file is parsed by the scripts to define
 #   - `MICROMAMBA_VERSION` in `scripts/build.sh`
 #   - `MAMBA_VERSION` in `scripts/test.sh`
-{% set mamba_version = "2.0.8" %}
+{% set mamba_version = "2.1.0" %}
 
 name: Miniforge3
 version: {{ version }}


### PR DESCRIPTION
I wonder whether this could be automated.

I am only updating mamba because conda 25.4.0 is not out yet.

cc @hmaarrfk.