### PR TITLE
fix path environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ the Miniforge Prompt.
 conda init
 ```
 
-Note that one can also just add the `C:\Users\myusername\miniforge3\condabin` folder
+Note that one can also just add the `C:\Users\myusername\miniforge3\condabin\` folder
 to the path environment variable
 [manually](https://learn.microsoft.com/en-us/previous-versions/office/developer/sharepoint-2010/ee537574(v=office.14)#to-add-a-path-to-the-path-environment-variable)
 so `conda` and `mamba` may be used more conveniently from any command prompt with limited


### PR DESCRIPTION
A '\' should be added at the end of the environment variable.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
