### PR TITLE
Refine `on` triggers in GHA workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,11 @@
 name: Build miniforge
-on: [ push, pull_request ]
+on: 
+  push:
+    branches:
+      - main
+    tags:
+      - '**'
+  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,11 +1,18 @@
 name: Build docs
-on: [ push, pull_request ]
+on: 
+  push:
+    branches:
+      - main
+    tags:
+      - '**'
+  pull_request:
+
 jobs:
   docs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        shell: bash -l {0}
+        shell: bash -el {0}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5 # v4.0.1


### PR DESCRIPTION
Without this, opening a PR from a branch results in double the CI jobs for no good reason.