### PR TITLE
Bump conda-libmamba-solver to 26.4.2

### DIFF
--- a/Miniforge3/construct.yaml
+++ b/Miniforge3/construct.yaml
@@ -1,5 +1,5 @@
 {% set version = os.environ.get("MINIFORGE_VERSION", "26.3.2-0") %}
-{% set conda_libmamba_solver_version = "26.4.0" %}
+{% set conda_libmamba_solver_version = "26.4.2" %}
 # This file is parsed by the scripts to define
 #   - `MICROMAMBA_VERSION` in `scripts/build.sh`
 #   - `MAMBA_VERSION` in `scripts/test.sh`

--- a/Miniforge3/construct.yaml
+++ b/Miniforge3/construct.yaml
@@ -1,4 +1,4 @@
-{% set version = os.environ.get("MINIFORGE_VERSION", "26.3.2-0") %}
+{% set version = os.environ.get("MINIFORGE_VERSION", "26.3.2-1") %}
 {% set conda_libmamba_solver_version = "26.4.2" %}
 # This file is parsed by the scripts to define
 #   - `MICROMAMBA_VERSION` in `scripts/build.sh`

--- a/Miniforge3/construct.yaml
+++ b/Miniforge3/construct.yaml
@@ -1,4 +1,4 @@
-{% set version = os.environ.get("MINIFORGE_VERSION", "26.3.2-1") %}
+{% set version = os.environ.get("MINIFORGE_VERSION", "26.3.2-2") %}
 {% set conda_libmamba_solver_version = "26.4.2" %}
 # This file is parsed by the scripts to define
 #   - `MICROMAMBA_VERSION` in `scripts/build.sh`


### PR DESCRIPTION
conda-libmamba-solver 26.4.0 (currently shipped in miniforge 26.3.2-1) has a database locking bug in `shards_cache.py` that causes `sqlite3.OperationalError: database is locked` during concurrent solves.

This is breaking downstream CI (e.g. conda's own test suite) because the base miniforge environment ships 26.4.0, and the locking error hits during dependency installation before the test environment can even be set up.

The fix landed in 26.4.1 (https://github.com/conda/conda-libmamba-solver/releases/tag/26.4.1) with further improvements in 26.4.2 (https://github.com/conda/conda-libmamba-solver/releases/tag/26.4.2).

Example failure: https://github.com/conda/conda/actions/runs/25867286560/job/76012696400?pr=16096