### PR TITLE
Add clarification regarding shell initialization for the macOS pkg installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,8 @@ or [Intel](https://github.com/conda-forge/miniforge/releases/latest/download/Min
 and follow the steps on screen by pressing Continue.
 
 By the 4th screen, you can choose a different installation path by clicking on "Change Install Location".
-Other options may be available behind the "Customise" button.
+Other options may be available behind the "Customise" button. Importantly, you can choose to have the intaller
+perform conda intialization for your shell.
 
 Once ready, click on Install. If everything went according to plan, the Summary page will report success.
 

--- a/README.md
+++ b/README.md
@@ -184,8 +184,8 @@ or [Intel](https://github.com/conda-forge/miniforge/releases/latest/download/Min
 and follow the steps on screen by pressing Continue.
 
 By the 4th screen, you can choose a different installation path by clicking on "Change Install Location".
-Other options may be available behind the "Customise" button. Importantly, you can choose to have the intaller
-perform conda intialization for your shell.
+Other options may be available behind the "Customise" button. Importantly, you can choose to have the installer
+perform conda initialization for your shell.
 
 Once ready, click on Install. If everything went according to plan, the Summary page will report success.
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)

I was helping an end user, for the first time using the PKG installer on macOS instead of the script installer. It went great, but their shell wasn't initialized. I was confused, because I didn't see any prompt for it and eventually realized it was in the Customize option.
So here I just update the README to make that more clear.
Note: it might be worth making that the default in the GUI installer? 

