### PR TITLE
Bump to conda 26.5.3, conda-libmamba-solver 26.7.0, Python 3.14

### DIFF
--- a/Miniforge3/construct.yaml
+++ b/Miniforge3/construct.yaml
@@ -1,10 +1,10 @@
-{% set version = os.environ.get("MINIFORGE_VERSION", "26.3.2-3") %}
-{% set conda_libmamba_solver_version = "26.4.2" %}
+{% set version = os.environ.get("MINIFORGE_VERSION", "26.5.3-0") %}
+{% set conda_libmamba_solver_version = "26.7.0" %}
 # This file is parsed by the scripts to define
 #   - `MICROMAMBA_VERSION` in `scripts/build.sh`
 #   - `MAMBA_VERSION` in `scripts/test.sh`
 # FUTURE: Update again when https://github.com/conda-forge/miniforge/issues/883 is addressed
-{% set mamba_version = "2.5.0" %}
+{% set mamba_version = "2.8.0" %}
 
 name: Miniforge3
 version: {{ version }}
@@ -33,7 +33,7 @@ initialize_conda: True
 initialize_by_default: False
 
 user_requested_specs:
-  - python 3.13.*
+  - python 3.14.*
   - conda >={{ version.split("-")[0] }}
   - mamba >={{ mamba_version }}
   - pip
@@ -41,7 +41,7 @@ user_requested_specs:
   - miniforge_console_shortcut 1.*  # [win]
 
 specs:
-  - python 3.13.*
+  - python 3.14.*
   - conda {{ version.split("-")[0] }}
   - mamba {{ mamba_version }}
   - conda-libmamba-solver {{ conda_libmamba_solver_version }}

--- a/Miniforge3/construct.yaml
+++ b/Miniforge3/construct.yaml
@@ -4,7 +4,7 @@
 #   - `MICROMAMBA_VERSION` in `scripts/build.sh`
 #   - `MAMBA_VERSION` in `scripts/test.sh`
 # FUTURE: Update again when https://github.com/conda-forge/miniforge/issues/883 is addressed
-{% set mamba_version = "2.8.0" %}
+{% set mamba_version = "2.5.0" %}
 
 name: Miniforge3
 version: {{ version }}

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ on Windows, edit with `notepad $PROFILE`) the activation command.
 
 ## Requirements and installers
 
-Latest installers with Python 3.13 `(*)` in the base environment:
+Latest installers with Python 3.14 `(*)` in the base environment:
 
 | OS      | Architecture                  | Minimum Version | File                                |
 | ------- | ----------------------------- | --------------- | ----------------------------------- |
@@ -104,6 +104,22 @@ The versions listed as "System: 32-bit" are not compatible with the installers o
 
 `(****)` The Windows installer requires Windows 10 or later. However, we are unsure exactly what version of Windows 10.
 We need [help](https://github.com/conda-forge/miniforge/issues/599) from users to maintain the backlog of windows questions.
+
+### Support for Python 3.13 in the base environment
+
+The base environment switched from Python 3.13 to Python 3.14 in version
+26.5.3-0. The last release with Python 3.13 in the base environment is
+26.3.2-3, available at
+https://github.com/conda-forge/miniforge/releases/tag/26.3.2-3
+
+In most cases you do not need an older installer: as noted in `(*)` above, the
+base environment's Python version does not limit the Python versions you can
+install elsewhere, so you can keep the latest installer and create an
+environment with the version you need, for example
+
+```sh
+conda create --name my_project python=3.13
+```
 
 ## Install
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -43,8 +43,7 @@ ls -al "${TEMP_DIR}"
 if [[ "${TARGET_PLATFORM}" != win-* ]]; then
     # Assumes specific structure in construct.yaml
     MICROMAMBA_VERSION=$(grep "set mamba_version" Miniforge3/construct.yaml | cut -d '=' -f 2 | cut -d '"' -f 2)
-   #  MICROMAMBA_BUILD=0
-    MICROMAMBA_BUILD=2
+    MICROMAMBA_BUILD=0
     mkdir "${TEMP_DIR}/micromamba"
     pushd "${TEMP_DIR}/micromamba"
     MICROMAMBA_SOURCE_URL="${MICROMAMBA_SOURCE_URL:-https://anaconda.org/conda-forge/micromamba/${MICROMAMBA_VERSION}/download/${TARGET_PLATFORM}/micromamba-${MICROMAMBA_VERSION}-${MICROMAMBA_BUILD}.tar.bz2}"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -43,7 +43,8 @@ ls -al "${TEMP_DIR}"
 if [[ "${TARGET_PLATFORM}" != win-* ]]; then
     # Assumes specific structure in construct.yaml
     MICROMAMBA_VERSION=$(grep "set mamba_version" Miniforge3/construct.yaml | cut -d '=' -f 2 | cut -d '"' -f 2)
-    MICROMAMBA_BUILD=0
+    # MICROMAMBA_BUILD=0
+    MICROMAMBA_BUILD=2
     mkdir "${TEMP_DIR}/micromamba"
     pushd "${TEMP_DIR}/micromamba"
     MICROMAMBA_SOURCE_URL="${MICROMAMBA_SOURCE_URL:-https://anaconda.org/conda-forge/micromamba/${MICROMAMBA_VERSION}/download/${TARGET_PLATFORM}/micromamba-${MICROMAMBA_VERSION}-${MICROMAMBA_BUILD}.tar.bz2}"


### PR DESCRIPTION
`conda` 26.7.0 is up, let's bump one step from 26.5.3