### PR TITLE
Updae to conda 26.7.2, mamba 2.9.0 and add support for linux-riscv64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,11 +52,8 @@ jobs:
             DOCKER_ARCH: amd64
             DOCKERIMAGE: condaforge/linux-anvil-x86_64:alma10
             OS_NAME: "Linux"
-            # Reduce the test matrix because the builds timeouts on emulated architectures
-            # The time consuming operation is an attempt a full solve of conda/mamba/boa
-            # for as a compatibility
-            # xref https://github.com/conda-forge/miniforge/pull/361
-            TEST_IMAGE_NAMES: "ubuntu:24.04"
+            # No testing until docker image has been created
+            TEST_IMAGE_NAMES: " "
 
           - os: ubuntu-latest
             ARCH: x86_64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,18 @@ jobs:
             TEST_IMAGE_NAMES: "ubuntu:24.04"
 
           - os: ubuntu-latest
+            ARCH: riscv64
+            TARGET_PLATFORM: linux-riscv64
+            DOCKER_ARCH: amd64
+            DOCKERIMAGE: condaforge/linux-anvil-x86_64:alma10
+            OS_NAME: "Linux"
+            # Reduce the test matrix because the builds timeouts on emulated architectures
+            # The time consuming operation is an attempt a full solve of conda/mamba/boa
+            # for as a compatibility
+            # xref https://github.com/conda-forge/miniforge/pull/361
+            TEST_IMAGE_NAMES: "ubuntu:24.04"
+
+          - os: ubuntu-latest
             ARCH: x86_64
             TARGET_PLATFORM: linux-64
             DOCKER_ARCH: amd64

--- a/Miniforge3/construct.yaml
+++ b/Miniforge3/construct.yaml
@@ -4,7 +4,7 @@
 #   - `MICROMAMBA_VERSION` in `scripts/build.sh`
 #   - `MAMBA_VERSION` in `scripts/test.sh`
 # FUTURE: Update again when https://github.com/conda-forge/miniforge/issues/883 is addressed
-{% set mamba_version = "2.5.0" %}
+{% set mamba_version = "2.9.0" %}
 
 name: Miniforge3
 version: {{ version }}

--- a/Miniforge3/construct.yaml
+++ b/Miniforge3/construct.yaml
@@ -1,4 +1,4 @@
-{% set version = os.environ.get("MINIFORGE_VERSION", "26.5.3-0") %}
+{% set version = os.environ.get("MINIFORGE_VERSION", "26.7.2-0") %}
 {% set conda_libmamba_solver_version = "26.7.0" %}
 # This file is parsed by the scripts to define
 #   - `MICROMAMBA_VERSION` in `scripts/build.sh`

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Latest installers with Python 3.14 `(*)` in the base environment:
 | Linux   | x86_64 (amd64)                | glibc >= 2.17   | `Miniforge3-Linux-x86_64.sh`        |
 | Linux   | aarch64 (arm64) `(**)`        | glibc >= 2.17   | `Miniforge3-Linux-aarch64.sh`       |
 | Linux   | ppc64le (POWER8/9)            | glibc >= 2.17   | `Miniforge3-Linux-ppc64le.sh`       |
+| Linux   | riscv64 (rv64gc) `(***)`      | glibc >= 2.29   | `Miniforge3-Linux-riscv64.sh`       |
 | macOS   | x86_64                        | macOS >= 11.0   | `Miniforge3-MacOSX-x86_64.{sh,pkg}` |
 | macOS   | arm64 (Apple Silicon) `(***)` | macOS >= 11.0   | `Miniforge3-MacOSX-arm64.{sh,pkg}`  |
 | Windows | x86_64 `(****)`               | Windows >= 10   | `Miniforge3-Windows-x86_64.exe`     |
@@ -100,7 +101,7 @@ or
 [Ubuntu for Raspberry PI](https://ubuntu.com/raspberry-pi).
 The versions listed as "System: 32-bit" are not compatible with the installers on this website.
 
-`(***)` Apple silicon builds are experimental and haven't had testing like the other platforms.
+`(***)` Apple silicon and Linux RISC-V builds are experimental and haven't had testing like the other platforms.
 
 `(****)` The Windows installer requires Windows 10 or later. However, we are unsure exactly what version of Windows 10.
 We need [help](https://github.com/conda-forge/miniforge/issues/599) from users to maintain the backlog of windows questions.

--- a/build_miniforge.sh
+++ b/build_miniforge.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Build miniforge installers for Linux
-# on various architectures (aarch64, x86_64, ppc64le)
+# on various architectures (aarch64, x86_64, ppc64le, riscv64)
 # Notes:
 # It uses the qemu emulator (see [1] or [2]) to enable
 # the use of containers images with different architectures than the host

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -60,7 +60,9 @@ if [[ "${TARGET_PLATFORM}" != win-* ]]; then
 fi
 
 echo "***** Set virtual package versions *****"
-if [[ "${TARGET_PLATFORM}" == linux-* ]]; then
+if [[ "${TARGET_PLATFORM}" == linux-riscv64 ]]; then
+    export CONDA_OVERRIDE_GLIBC=2.39
+elif [[ "${TARGET_PLATFORM}" == linux-* ]]; then
     export CONDA_OVERRIDE_GLIBC=2.17
 elif [[ "${TARGET_PLATFORM}" == osx-64 ]]; then
     export CONDA_OVERRIDE_OSX=11.0

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -43,8 +43,7 @@ ls -al "${TEMP_DIR}"
 if [[ "${TARGET_PLATFORM}" != win-* ]]; then
     # Assumes specific structure in construct.yaml
     MICROMAMBA_VERSION=$(grep "set mamba_version" Miniforge3/construct.yaml | cut -d '=' -f 2 | cut -d '"' -f 2)
-    # MICROMAMBA_BUILD=0
-    MICROMAMBA_BUILD=2
+    MICROMAMBA_BUILD=0
     mkdir "${TEMP_DIR}/micromamba"
     pushd "${TEMP_DIR}/micromamba"
     MICROMAMBA_SOURCE_URL="${MICROMAMBA_SOURCE_URL:-https://anaconda.org/conda-forge/micromamba/${MICROMAMBA_VERSION}/download/${TARGET_PLATFORM}/micromamba-${MICROMAMBA_VERSION}-${MICROMAMBA_BUILD}.tar.bz2}"


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
