### PR TITLE
Add --override-frozen to conda.exe install in test.sh

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -43,7 +43,7 @@ if [[ "$(uname)" == MINGW* ]]; then
   conda.exe list | grep msys2 && exit 1
 
   echo "***** Check if we can install a package which requires msys2 *****"
-  conda.exe install r-base --yes --quiet
+  conda.exe install r-base --yes --quiet --override-frozen
   conda.exe list
 else
   # Test one of our installers in batch mode


### PR DESCRIPTION
When constructor is configured with freeze_base (CEP-22), conda-meta/frozen is placed in the installed base environment. On Windows, scripts/test.sh runs conda.exe install r-base to check installation of msys2 dependencies. Without --override-frozen, this installation fails due to freeze protection in conda.

Fixes #895

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
